### PR TITLE
Cannot load globalgamemanager, Error when view MonoBehaviour containing uint and ulong

### DIFF
--- a/AssetTools.NET/Standard/AssetTypeClass/AssetTypeValueField.cs
+++ b/AssetTools.NET/Standard/AssetTypeClass/AssetTypeValueField.cs
@@ -80,6 +80,7 @@
                     return EnumValueTypes.ValueType_Int16;
                 case "uint16":
                 case "unsigned short":
+                case "ushort":
                     return EnumValueTypes.ValueType_UInt16;
                 case "sint32":
                 case "int":
@@ -88,12 +89,14 @@
                     return EnumValueTypes.ValueType_Int32;
                 case "uint32":
                 case "unsigned int":
+                case "uint":
                     return EnumValueTypes.ValueType_UInt32;
                 case "sint64":
                 case "long":
                     return EnumValueTypes.ValueType_Int64;
                 case "uint64":
                 case "unsigned long":
+                case "ulong":
                     return EnumValueTypes.ValueType_UInt64;
                 case "single":
                 case "float":

--- a/UABE.NET/Winforms/AssetViewer.cs
+++ b/UABE.NET/Winforms/AssetViewer.cs
@@ -153,7 +153,7 @@ namespace UABE.NET.Winforms
         
         private string GetAssetNameFast(AssetFileInfoEx afi, ClassDatabaseFile cldb, ClassDatabaseType type, AssetsFileReader reader)
         {
-            if (type.fields.Count == 0) return type.name.GetString(cldb);
+            if (type.fields.Count <= 1) return type.name.GetString(cldb);
             if (type.fields[1].fieldName.GetString(cldb) == "m_Name")
             {
                 reader.Position = afi.absoluteFilePos;


### PR DESCRIPTION
1. Cannot load globalgamamanager because DelayedCallManager only have one child, so there is no second child (type.fields[1])
2. Error when view MonoBehaviour containing uint and ulong because if type string is uint or ulong, it recognize as ValueType_None.