### PR TITLE
Support Unity 4.X and ClassDatabase version 1

### DIFF
--- a/AssetTools.NET/Extra/MonoDeserializer/MonoDeserializer.cs
+++ b/AssetTools.NET/Extra/MonoDeserializer/MonoDeserializer.cs
@@ -17,11 +17,13 @@ namespace AssetsTools.NET.Extra
 {
     public class MonoClass
     {
+        static public uint format;
         public uint childrenCount;
         public AssetTypeTemplateField[] children;
         private AssemblyDefinition assembly;
-        public bool Read(string typeName, string assemblyLocation)
+        public bool Read(string typeName, string assemblyLocation, uint format)
         {
+            MonoClass.format = format;
             DefaultAssemblyResolver resolver = new DefaultAssemblyResolver();
             resolver.AddSearchDirectory(Path.GetDirectoryName(assemblyLocation));
             ReaderParameters readerParameters = new ReaderParameters();
@@ -48,7 +50,7 @@ namespace AssetsTools.NET.Extra
                 if (File.Exists(assemblyPath))
                 {
                     MonoClass mc = new MonoClass();
-                    mc.Read(scriptName, assemblyPath);
+                    mc.Read(scriptName, assemblyPath, MonoClass.format);
                     AssetTypeTemplateField[] monoTemplateFields = mc.children;
 
                     AssetTypeTemplateField[] templateField = baseField.children.Concat(monoTemplateFields).ToArray();
@@ -504,8 +506,16 @@ namespace AssetsTools.NET.Extra
 
             AssetTypeTemplateField pathID = new AssetTypeTemplateField();
             pathID.name = "m_PathID";
-            pathID.type = "SInt64";
-            pathID.valueType = EnumValueTypes.ValueType_Int64;
+            if (MonoClass.format < 0x10)
+            {
+                pathID.type = "int";
+                pathID.valueType = EnumValueTypes.ValueType_Int32;
+            }
+            else
+            {
+                pathID.type = "SInt64";
+                pathID.valueType = EnumValueTypes.ValueType_Int64;
+            }
             pathID.isArray = false;
             pathID.align = false;
             pathID.hasValue = true;

--- a/AssetTools.NET/Extra/MonoDeserializer/MonoDeserializer.cs
+++ b/AssetTools.NET/Extra/MonoDeserializer/MonoDeserializer.cs
@@ -17,13 +17,13 @@ namespace AssetsTools.NET.Extra
 {
     public class MonoClass
     {
-        static public uint format;
+        public uint format;
         public uint childrenCount;
         public AssetTypeTemplateField[] children;
         private AssemblyDefinition assembly;
         public bool Read(string typeName, string assemblyLocation, uint format)
         {
-            MonoClass.format = format;
+            this.format = format;
             DefaultAssemblyResolver resolver = new DefaultAssemblyResolver();
             resolver.AddSearchDirectory(Path.GetDirectoryName(assemblyLocation));
             ReaderParameters readerParameters = new ReaderParameters();
@@ -50,7 +50,7 @@ namespace AssetsTools.NET.Extra
                 if (File.Exists(assemblyPath))
                 {
                     MonoClass mc = new MonoClass();
-                    mc.Read(scriptName, assemblyPath, MonoClass.format);
+                    mc.Read(scriptName, assemblyPath, inst.file.header.format);
                     AssetTypeTemplateField[] monoTemplateFields = mc.children;
 
                     AssetTypeTemplateField[] templateField = baseField.children.Concat(monoTemplateFields).ToArray();
@@ -506,7 +506,7 @@ namespace AssetsTools.NET.Extra
 
             AssetTypeTemplateField pathID = new AssetTypeTemplateField();
             pathID.name = "m_PathID";
-            if (MonoClass.format < 0x10)
+            if (format < 0x10)
             {
                 pathID.type = "int";
                 pathID.valueType = EnumValueTypes.ValueType_Int32;

--- a/AssetTools.NET/Standard/AssetsFileFormat/AssetsFileReader.cs
+++ b/AssetTools.NET/Standard/AssetsFileFormat/AssetsFileReader.cs
@@ -1,4 +1,5 @@
 ﻿using System.IO;
+using System.Linq;
 using System.Text;
 
 namespace AssetsTools.NET
@@ -21,6 +22,22 @@ namespace AssetsTools.NET
             {
                 return bigEndian ? ReverseShort(base.ReadUInt16()) : base.ReadUInt16();
                 //return bigEndian ? BitConverter.ToUInt16(ReadBytes(2).Reverse().ToArray(), 0) : base.ReadUInt16();
+            }
+        }
+        public int ReadInt24()
+        {
+            unchecked
+            {
+                return bigEndian ? (int)ReverseInt((uint)System.BitConverter.ToInt32(ReadBytes(3).Concat(new byte[] { 0 }).ToArray(), 0)) :
+                    System.BitConverter.ToInt32(ReadBytes(3).Concat(new byte[] { 0 }).ToArray(), 0);
+            }
+        }
+        public uint ReadUInt24()
+        {
+            unchecked
+            {
+                return bigEndian ? ReverseInt(System.BitConverter.ToUInt32(ReadBytes(3).Concat(new byte[] { 0 }).ToArray(), 0)) :
+                    System.BitConverter.ToUInt32(ReadBytes(3).Concat(new byte[] { 0 }).ToArray(), 0);
             }
         }
         public override int ReadInt32()

--- a/AssetTools.NET/Standard/AssetsFileFormat/AssetsFileWriter.cs
+++ b/AssetTools.NET/Standard/AssetsFileFormat/AssetsFileWriter.cs
@@ -62,6 +62,22 @@ namespace AssetsTools.NET
         {
             base.Write(Encoding.ASCII.GetBytes(val));
         }
+        public void WriteUInt24(uint val)
+        {
+            unchecked
+            {
+                if(bigEndian) base.Write(System.BitConverter.GetBytes(ReverseInt(val)), 1, 3);
+                else base.Write(System.BitConverter.GetBytes(val), 0, 3);
+            }
+        }
+        public void WriteInt24(int val)
+        {
+            unchecked
+            {
+                if (bigEndian) base.Write(System.BitConverter.GetBytes((int)ReverseInt((uint)val)), 1, 3);
+                else base.Write(System.BitConverter.GetBytes(val), 0, 3);
+            }
+        }
         public ushort ReverseShort(ushort value)
         {
             return (ushort)(((value & 0xFF00) >> 8) | (value & 0x00FF) << 8);

--- a/AssetTools.NET/Standard/AssetsFileFormat/TypeTree.cs
+++ b/AssetTools.NET/Standard/AssetsFileFormat/TypeTree.cs
@@ -26,7 +26,10 @@
                 type0d.Read(hasTypeTree, reader.Position, reader, version, version, bigEndian);
                 pTypes_Unity5[i] = type0d;
             }
-            if (version < 0x0E) dwUnknown = reader.ReadUInt32();
+            if (version < 0x0E)
+            {
+                dwUnknown = reader.ReadUInt24();
+            }
             _fmt = version; //-todo: figure out what the heck this is for. if ver = -1 on write does it set it to default or something?
             return reader.Position;
         }//Minimum AssetsFile format : 6
@@ -40,7 +43,10 @@
             {
                 pTypes_Unity5[i].Write(hasTypeTree, writer.Position, writer, version);
             }
-            if (version < 0x0E) writer.Write(dwUnknown);
+            if (version < 0x0E)
+            {
+                writer.WriteUInt24(dwUnknown);
+            }
             return writer.Position;
         }
 

--- a/AssetTools.NET/Standard/AssetsFileTable/AssetsFileTable.cs
+++ b/AssetTools.NET/Standard/AssetsFileTable/AssetsFileTable.cs
@@ -29,7 +29,14 @@ namespace AssetsTools.NET
                 AssetFileInfoEx assetFileInfoSet = new AssetFileInfoEx();
                 assetFileInfoSet.Read(pFile.header.format, reader.Position, reader, pFile.header.endianness == 1 ? true : false);
                 assetFileInfoSet.absoluteFilePos = pFile.header.offs_firstFile + assetFileInfoSet.offs_curFile;
-                assetFileInfoSet.curFileType = (uint)pFile.typeTree.pTypes_Unity5[assetFileInfoSet.curFileTypeOrIndex].classId;
+                if(pFile.header.format < 0x10)
+                {
+                    assetFileInfoSet.curFileType = (uint)assetFileInfoSet.curFileTypeOrIndex;
+                } else
+                {
+                    assetFileInfoSet.curFileType = (uint)pFile.typeTree.pTypes_Unity5[assetFileInfoSet.curFileTypeOrIndex].classId;
+                }
+                
                 pAssetFileInfo[i] = assetFileInfoSet;
             }
         }

--- a/AssetTools.NET/Standard/ClassDatabaseFile/ClassDatabaseFile.cs
+++ b/AssetTools.NET/Standard/ClassDatabaseFile/ClassDatabaseFile.cs
@@ -16,7 +16,9 @@ namespace AssetsTools.NET
         {
             header = new ClassDatabaseFileHeader();
             header.Read(reader, 0);
-            if (header.header != "cldb" || header.fileVersion != 3 || header.compressionType != 0)
+            if (header.header != "cldb" ||
+                !(header.fileVersion == 3 || header.fileVersion == 1) ||
+                header.compressionType != 0)
             {
                 valid = false;
                 return valid;

--- a/AssetTools.NET/Standard/ClassDatabaseFile/ClassDatabaseFileHeader.cs
+++ b/AssetTools.NET/Standard/ClassDatabaseFile/ClassDatabaseFileHeader.cs
@@ -21,11 +21,19 @@ namespace AssetsTools.NET
             header = reader.ReadStringLength(4);
             if (header != "cldb") return reader.Position;
             fileVersion = reader.ReadByte();
-            if (fileVersion != 3) return reader.Position;
-            compressionType = reader.ReadByte();
-            if (compressionType != 0) return reader.Position;
-            compressedSize = reader.ReadUInt32();
-            uncompressedSize = reader.ReadUInt32();
+            switch (fileVersion)
+            {
+                case 1:
+                    break;
+                case 3:
+                    compressionType = reader.ReadByte();
+                    if (compressionType != 0) return reader.Position;
+                    compressedSize = reader.ReadUInt32();
+                    uncompressedSize = reader.ReadUInt32();
+                    break;
+                default:
+                    return reader.Position;
+            }
             unityVersionCount = reader.ReadByte();
             pUnityVersions = new string[unityVersionCount];
             for (int i = 0; i < unityVersionCount; i++)
@@ -41,9 +49,19 @@ namespace AssetsTools.NET
             writer.bigEndian = false;
             writer.Write(Encoding.ASCII.GetBytes(header));
             writer.Write(fileVersion);
-            writer.Write(compressionType);
-            writer.Write(compressedSize);
-            writer.Write(uncompressedSize);
+            switch(fileVersion)
+            {
+                case 1:
+                    break;
+                case 3:
+                    writer.Write(compressionType);
+                    if (compressionType != 0) return writer.Position;
+                    writer.Write(compressedSize);
+                    writer.Write(uncompressedSize);
+                    break;
+                default:
+                    return writer.Position;
+            }
             writer.Write(unityVersionCount);
             for (int i = 0; i < unityVersionCount; i++)
             {

--- a/AssetTools.NET/Standard/ClassDatabaseFile/ClassDatabaseTypeField.cs
+++ b/AssetTools.NET/Standard/ClassDatabaseFile/ClassDatabaseTypeField.cs
@@ -19,8 +19,16 @@
             depth = reader.ReadByte();
             isArray = reader.ReadByte();
             size = reader.ReadUInt32();
-            version = reader.ReadUInt16();
-            flags2 = reader.ReadUInt32();
+            switch (version)
+            {
+                case 1:
+                    flags2 = reader.ReadUInt32();
+                    break;
+                case 3:
+                    this.version = reader.ReadUInt16();
+                    flags2 = reader.ReadUInt32();
+                    break;
+            }
             return reader.Position;
         }
         public ulong Write(AssetsFileWriter writer, ulong filePos, int version)
@@ -30,8 +38,16 @@
             writer.Write(depth);
             writer.Write(isArray);
             writer.Write(size);
-            writer.Write(this.version);
-            writer.Write(flags2);
+            switch (version)
+            {
+                case 1:
+                    writer.Write(flags2);
+                    break;
+                case 3:
+                    writer.Write(this.version);
+                    writer.Write(flags2);
+                    break;
+            }
             return writer.Position;
         }
     }

--- a/UABE.NET/Winforms/AssetData.cs
+++ b/UABE.NET/Winforms/AssetData.cs
@@ -34,7 +34,7 @@ namespace UABE.NET.Winforms
             AssetTypeTemplateField pBaseField = new AssetTypeTemplateField();
             pBaseField.FromClassDatabase(am.initialClassFile, cldt, 0);
             mainAti = new AssetTypeInstance(1, new[] { pBaseField }, af.reader, false, assetDetails.position);
-            if (assetDetails.monoType != 0xFFFF)
+            if (assetDetails.type == 0x72)
             {
                 AssetTypeTemplateField[] desMonos = TryDeserializeMono(mainAti);
                 if (desMonos != null)
@@ -87,7 +87,7 @@ namespace UABE.NET.Winforms
             if (File.Exists(assemblyPath))
             {
                 MonoClass mc = new MonoClass();
-                mc.Read(scriptName, assemblyPath);
+                mc.Read(scriptName, assemblyPath, af.header.format);
                 return mc.children;
             }
             else


### PR DESCRIPTION
I modify AssetsTools.NET support unity 4.x and can read ClassDatabase file for version 1,
but dirty about MonoClass.format member.
please consider about it and please review it