### PR TITLE
Improve memory usage by not duplicating full assets files into MemoryStreams

### DIFF
--- a/AssetTools.NET/AssetsTools.NET.csproj
+++ b/AssetTools.NET/AssetsTools.NET.csproj
@@ -4,6 +4,7 @@
     <OutputType>Library</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <Platforms>AnyCPU</Platforms>
+    <LangVersion>8</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
     <OutputPath>bin\x64\Debug\</OutputPath>

--- a/AssetTools.NET/Extra/AssetsManager/BundleFileInstance.cs
+++ b/AssetTools.NET/Extra/AssetsManager/BundleFileInstance.cs
@@ -1,8 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text;
 
 namespace AssetsTools.NET.Extra
 {
@@ -21,24 +18,17 @@ namespace AssetsTools.NET.Extra
             name = Path.Combine(root, Path.GetFileName(path));
             file = new AssetBundleFile();
             file.Read(new AssetsFileReader(stream), true);
-            if (file.bundleHeader6.GetCompressionType() != 0 && unpackIfPacked)
+            if (file.bundleHeader6 != null && file.bundleHeader6.GetCompressionType() != 0 && unpackIfPacked)
             {
                 file = BundleHelper.UnpackBundle(file);
+                this.stream = file.reader.BaseStream;
             }
             loadedAssetsFiles = new List<AssetsFileInstance>();
         }
+
         public BundleFileInstance(FileStream stream, string root, bool unpackIfPacked)
+            : this(stream, stream.Name, root, unpackIfPacked)
         {
-            this.stream = stream;
-            path = stream.Name;
-            name = Path.Combine(root, Path.GetFileName(path));
-            file = new AssetBundleFile();
-            file.Read(new AssetsFileReader(stream), true);
-            if (file.bundleHeader6.GetCompressionType() != 0 && unpackIfPacked)
-            {
-                file = BundleHelper.UnpackBundle(file);
-            }
-            loadedAssetsFiles = new List<AssetsFileInstance>();
         }
     }
 }

--- a/AssetTools.NET/Extra/SegmentStream.cs
+++ b/AssetTools.NET/Extra/SegmentStream.cs
@@ -1,0 +1,111 @@
+﻿using System;
+using System.IO;
+
+namespace AssetsTools.NET.Extra
+{
+    internal class SegmentStream : Stream
+    {
+        private readonly long length;
+
+        public SegmentStream(Stream baseStream, long baseOffset)
+            : this(baseStream, baseOffset, -1)
+        {
+        }
+
+        public SegmentStream(Stream baseStream, long baseOffset, long length)
+        {
+            if (baseOffset < 0 || baseOffset > baseStream.Length)
+                throw new ArgumentOutOfRangeException(nameof(baseOffset));
+
+            if (length >= 0 && baseOffset + length > baseStream.Length)
+                throw new ArgumentOutOfRangeException(nameof(length));
+
+            BaseStream = baseStream;
+            BaseOffset = baseOffset;
+            this.length = length;
+        }
+
+        public Stream BaseStream
+        {
+            get;
+        }
+
+        public long BaseOffset
+        {
+            get;
+        }
+
+        public override long Position
+        {
+            get;
+            set;
+        }
+
+        public override long Length
+        {
+            get { return length >= 0 ? length : BaseStream.Length - BaseOffset; }
+        }
+
+        public override void Flush()
+        {
+            BaseStream.Flush();
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            BaseStream.Position = BaseOffset + Position;
+            count = BaseStream.Read(buffer, offset, (int)Math.Min(count, Length - Position));
+            Position += count;
+            return count;
+        }
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            long newPosition;
+            switch (origin)
+            {
+                case SeekOrigin.Begin:
+                    newPosition = offset;
+                    break;
+
+                case SeekOrigin.Current:
+                    newPosition = Position + offset;
+                    break;
+
+                case SeekOrigin.End:
+                    newPosition = Position + Length + offset;
+                    break;
+
+                default:
+                    throw new ArgumentException();
+            }
+
+            if (newPosition < 0 || newPosition > Length)
+                throw new ArgumentOutOfRangeException(nameof(offset));
+
+            Position = newPosition;
+            return Position;
+        }
+
+        public override void SetLength(long value)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            if (length >= 0 && count > Length - Position)
+                throw new ArgumentOutOfRangeException(nameof(count));
+
+            BaseStream.Position = BaseOffset + Position;
+            BaseStream.Write(buffer, offset, count);
+            Position += count;
+        }
+
+        public override bool CanRead => BaseStream.CanRead;
+
+        public override bool CanSeek => BaseStream.CanSeek;
+
+        public override bool CanWrite => BaseStream.CanWrite;
+    }
+}

--- a/AssetTools.NET/Standard/AssetsBundleFileFormat/AssetsBundleEntry.cs
+++ b/AssetTools.NET/Standard/AssetsBundleFileFormat/AssetsBundleEntry.cs
@@ -4,6 +4,6 @@
     {
         public uint offset;
         public uint length;
-        public byte name;
+        public string name;
     }
 }

--- a/AssetTools.NET/Standard/AssetsFileFormat/AssetsFileReader.cs
+++ b/AssetTools.NET/Standard/AssetsFileFormat/AssetsFileReader.cs
@@ -9,7 +9,17 @@ namespace AssetsTools.NET
         //todo, this should default to bigEndian = false
         //since it's more likely little endian than big endian
         public bool bigEndian = true;
-        public AssetsFileReader(Stream stream) : base(stream) { }
+
+        public AssetsFileReader(string filePath)
+            : base(File.OpenRead(filePath))
+        {
+        }
+        
+        public AssetsFileReader(Stream stream)
+            : base(stream)
+        {
+        }
+
         public override short ReadInt16()
         {
             unchecked

--- a/AssetTools.NET/Standard/AssetsFileFormat/AssetsFileWriter.cs
+++ b/AssetTools.NET/Standard/AssetsFileFormat/AssetsFileWriter.cs
@@ -7,9 +7,27 @@ namespace AssetsTools.NET
     public class AssetsFileWriter : BinaryWriter
     {
         public bool bigEndian = true;
-        public AssetsFileWriter(FileStream fileStream) : base(fileStream) { }
-        public AssetsFileWriter(MemoryStream memoryStream) : base(memoryStream) { }
-        public AssetsFileWriter(Stream stream) : base(stream) { }
+
+        public AssetsFileWriter(string filePath)
+            : base(File.Open(filePath, FileMode.Create, FileAccess.Write))
+        {
+        }
+        
+        public AssetsFileWriter(FileStream fileStream)
+            : base(fileStream)
+        {
+        }
+        
+        public AssetsFileWriter(MemoryStream memoryStream)
+            : base(memoryStream)
+        {
+        }
+        
+        public AssetsFileWriter(Stream stream)
+            : base(stream)
+        {
+        }
+        
         public override void Write(short val)
         {
             unchecked

--- a/AssetTools.NET/Standard/BundleReplacer/BundleReplacerFromAssets.cs
+++ b/AssetTools.NET/Standard/BundleReplacer/BundleReplacerFromAssets.cs
@@ -1,6 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.IO;
+using AssetsTools.NET.Extra;
 
 namespace AssetsTools.NET
 {
@@ -8,79 +8,74 @@ namespace AssetsTools.NET
     {
         private readonly string oldName;
         private readonly string newName;
-        private readonly List<AssetsReplacer> replacers;
-        private readonly uint fileId;
         private readonly int bundleListIndex;
         private AssetsFile assetsFile;
-        private ClassDatabaseFile typeMeta;
+        private readonly List<AssetsReplacer> assetReplacers;
 
-        public BundleReplacerFromAssets(string oldName, string newName, AssetsFile assetsFile, List<AssetsReplacer> replacers, uint fileId, int bundleListIndex = -1)
+        public BundleReplacerFromAssets(string oldName, string newName, AssetsFile assetsFile, List<AssetsReplacer> assetReplacers, uint fileId = 0, int bundleListIndex = -1)
         {
             this.oldName = oldName;
-            if (newName == null)
-                this.newName = oldName;
-            else
-                this.newName = newName;
+            this.newName = newName ?? oldName;
             this.assetsFile = assetsFile;
-            this.replacers = replacers;
-            this.fileId = fileId;
+            this.assetReplacers = assetReplacers;
             this.bundleListIndex = bundleListIndex;
         }
+
         public override BundleReplacementType GetReplacementType()
         {
             return BundleReplacementType.AddOrModify;
         }
+
         public override int GetBundleListIndex()
         {
             return bundleListIndex;
         }
+
         public override string GetOriginalEntryName()
         {
             return oldName;
         }
+
         public override string GetEntryName()
         {
             return newName;
         }
+
         public override long GetSize()
         {
             return -1; //todo
         }
+
         public override bool Init(AssetsFileReader entryReader, long entryPos, long entrySize, ClassDatabaseFile typeMeta = null)
         {
             if (assetsFile != null)
                 return false;
 
-            this.typeMeta = typeMeta;
-
-            entryReader.Position = entryPos;
-            //memorystream for alignment issue
-            MemoryStream ms = new MemoryStream();
-            AssetsFileReader r = new AssetsFileReader(ms);
-            AssetsFileWriter w = new AssetsFileWriter(ms);
-            {
-                w.Write(entryReader.ReadBytes((int)entrySize));
-                ms.Position = 0;
-                assetsFile = new AssetsFile(r);
-            }
+            SegmentStream stream = new SegmentStream(entryReader.BaseStream, entryPos, entrySize);
+            AssetsFileReader reader = new AssetsFileReader(stream);
+            assetsFile = new AssetsFile(reader);
             return true;
         }
+
         public override void Uninit()
         {
             assetsFile.Close();
-            return;
         }
+
         public override long Write(AssetsFileWriter writer)
         {
-            //memorystream for alignment issue
-            using (MemoryStream ms = new MemoryStream())
-            using (AssetsFileWriter w = new AssetsFileWriter(ms))
-            {
-                assetsFile.Write(w, -1, replacers, fileId, typeMeta);
-                writer.Write(ms.ToArray());
-            }
+            // Some parts of an assets file need to be aligned to a multiple of 4/8/16 bytes,
+            // but for this to work correctly, the start of the file of course needs to be aligned too.
+            // In a loose .assets file this is true by default, but inside a bundle file,
+            // this might not be the case. Therefore wrap the bundle output stream in a SegmentStream
+            // which will make it look like the start of the new assets file is at position 0
+            SegmentStream alignedStream = new SegmentStream(writer.BaseStream, writer.Position);
+            AssetsFileWriter alignedWriter = new AssetsFileWriter(alignedStream);
+            assetsFile.Write(alignedWriter, -1, assetReplacers);
+            writer.Position = writer.BaseStream.Length;
             return writer.Position;
         }
+
         public override long WriteReplacer(AssetsFileWriter writer)
         {
             writer.Write((short)4); //replacer type
@@ -88,14 +83,15 @@ namespace AssetsTools.NET
             writer.WriteCountStringInt16(oldName);
             writer.WriteCountStringInt16(newName);
             writer.Write((byte)1); //probably hasSerializedData
-            writer.Write((long)replacers.Count);
-            foreach (AssetsReplacer replacer in replacers)
+            writer.Write((long)assetReplacers.Count);
+            foreach (AssetsReplacer replacer in assetReplacers)
             {
                 replacer.WriteReplacer(writer);
             }
 
             return writer.Position;
         }
+
         public override bool HasSerializedData()
         {
             return true;


### PR DESCRIPTION
Adds the new SegmentStream class and introduces it in the following places:
- AssetsManager.LoadAssetsFileFromBundle()
- BundleHelper.LoadAssetFromBundle()
- BundleReplacerFromAssets.Write()

In each of these cases, rather than putting the complete assets file in memory and creating a MemoryStream on top of that, we now create a proxy stream that represents a segment of the underlying bundle stream.