### PR TITLE
Fixes

### DIFF
--- a/AssetTools.NET/Extra/AssetsManager/AssetsManager.cs
+++ b/AssetTools.NET/Extra/AssetsManager/AssetsManager.cs
@@ -31,7 +31,7 @@ namespace AssetsTools.NET.Extra
         {
             UnloadAllAssetsFiles(true);
             UnloadAllBundleFiles();
-            MonoTempGenerator.Dispose();
+            MonoTempGenerator?.Dispose();
             if (unloadClassData)
             {
                 ClassPackage = null;

--- a/AssetTools.NET/Standard/AssetsFileFormat/AssetsFileExternal.cs
+++ b/AssetTools.NET/Standard/AssetsFileFormat/AssetsFileExternal.cs
@@ -31,8 +31,7 @@ namespace AssetsTools.NET
         public void Read(AssetsFileReader reader)
         {
             VirtualAssetPathName = reader.ReadNullTerminated();
-            Guid = new GUID128();
-            Guid.Read(reader);
+            Guid = new GUID128(reader);
             Type = (AssetsFileExternalType)reader.ReadInt32();
             PathName = reader.ReadNullTerminated();
             OriginalPathName = PathName;

--- a/AssetTools.NET/Standard/AssetsFileFormat/GUID128.cs
+++ b/AssetTools.NET/Standard/AssetsFileFormat/GUID128.cs
@@ -15,6 +15,11 @@ namespace AssetsTools.NET
 
         public bool IsEmpty => data0 == 0 && data1 == 0 && data2 == 0 && data3 == 0;
 
+        public GUID128(AssetsFileReader reader) : this()
+        {
+            Read(reader);
+        }
+
         public void Read(AssetsFileReader reader)
         {
             data0 = reader.ReadUInt32();


### PR DESCRIPTION
Regarding GUID128, turns out getter returns completely new struct, so despite `Guid.Read()` previously working (while it was a field) it doesn't now, since you call read on a *different* copy of Guid