### PR TITLE
Fix MonoGenerator fields of generic-implementation types

### DIFF
--- a/AssetTools.NET/Extra/MonoDeserializer/MonoCecilTempGenerator.cs
+++ b/AssetTools.NET/Extra/MonoDeserializer/MonoCecilTempGenerator.cs
@@ -214,7 +214,7 @@ namespace AssetsTools.NET.Extra
 
                         TypeDefinition ftd = ft.typeDef;
 
-                        if (f.FieldType is GenericInstanceType gft)
+                        if (ft.typeRef is GenericInstanceType gft)
                         {
                             //Unity can't serialize list of collections, ignoring it
                             if (gft.ElementType.FullName == "System.Collections.Generic.List`1")
@@ -235,7 +235,7 @@ namespace AssetsTools.NET.Extra
                             }
                         }
                         //Unity can't serialize array of collections, ignoring it
-                        else if (f.FieldType is ArrayType aft)
+                        else if (ft.typeRef is ArrayType aft)
                         {
                             TypeDefWithSelfRef elem = aft.ElementType;
                             if (!elem.typeRef.IsArray && IsValidDef(elem.typeDef))


### PR DESCRIPTION
For a case like this:
```cs
[Serializable]
public class BaseTestClass<T>
{
    public T value;
}
[Serializable]
public class TestClass2 : BaseTestClass<List<string>> { }
```
`value` was not serialized, while it should've been, because it was using generic definition `T` instead of actual `List<string>` type.