### PR TITLE
MonoCecilTempGenerator and dependency loading Fixes

### DIFF
--- a/AssetTools.NET/Extra/AssetsManager/AssetsFileInstance.cs
+++ b/AssetTools.NET/Extra/AssetsManager/AssetsFileInstance.cs
@@ -49,11 +49,11 @@ namespace AssetsTools.NET.Extra
 
                     if (File.Exists(absPath))
                     {
-                        dependencyCache[depIdx] = am.LoadAssetsFile(File.OpenRead(absPath), true);
+                        dependencyCache[depIdx] = am.LoadAssetsFile(absPath, true);
                     }
                     else if (File.Exists(localAbsPath))
                     {
-                        dependencyCache[depIdx] = am.LoadAssetsFile(File.OpenRead(localAbsPath), true);
+                        dependencyCache[depIdx] = am.LoadAssetsFile(localAbsPath, true);
                     }
                     else if (parentBundle != null)
                     {

--- a/AssetTools.NET/Extra/AssetsManager/AssetsManager.Dependency.cs
+++ b/AssetTools.NET/Extra/AssetsManager/AssetsManager.Dependency.cs
@@ -25,11 +25,11 @@ namespace AssetsTools.NET.Extra
                     string localAbsPath = Path.Combine(fileDir, Path.GetFileName(depPath));
                     if (File.Exists(absPath))
                     {
-                        LoadAssetsFile(File.OpenRead(absPath), true);
+                        LoadAssetsFile(absPath, true);
                     }
                     else if (File.Exists(localAbsPath))
                     {
-                        LoadAssetsFile(File.OpenRead(localAbsPath), true);
+                        LoadAssetsFile(localAbsPath, true);
                     }
                 }
             }
@@ -64,19 +64,19 @@ namespace AssetsTools.NET.Extra
                     }
                     else if (File.Exists(absPath))
                     {
-                        LoadAssetsFile(File.OpenRead(absPath), true);
+                        LoadAssetsFile(absPath, true);
                     }
                     else if (File.Exists(localAbsPath))
                     {
-                        LoadAssetsFile(File.OpenRead(localAbsPath), true);
+                        LoadAssetsFile(localAbsPath, true);
                     }
                     else if (File.Exists(nbAbsPath))
                     {
-                        LoadAssetsFile(File.OpenRead(nbAbsPath), true);
+                        LoadAssetsFile(nbAbsPath, true);
                     }
                     else if (File.Exists(nbLocalAbsPath))
                     {
-                        LoadAssetsFile(File.OpenRead(nbLocalAbsPath), true);
+                        LoadAssetsFile(nbLocalAbsPath, true);
                     }
                 }
             }

--- a/AssetTools.NET/Extra/MonoDeserializer/MonoCecilTempGenerator.cs
+++ b/AssetTools.NET/Extra/MonoDeserializer/MonoCecilTempGenerator.cs
@@ -256,16 +256,17 @@ namespace AssetsTools.NET.Extra
             
             bool IsValidDef(TypeDefinition def)
             {
-                return !def.IsAbstract && 
-                       !def.IsInterface &&
-                       (def.IsPrimitive ||
-                        def.IsEnum ||
-                        def.FullName == "System.String" ||
-                        !blacklistedAssemblies.Contains((def.Scope as ModuleDefinition)?.Assembly.Name.Name ?? def.Scope.Name)) &&
-                       (def.IsEnum ||
-                       def.IsSerializable ||
+                if (!(def.IsPrimitive ||
+                    def.IsEnum ||
+                    def.FullName == "System.String" ||
+                    !blacklistedAssemblies.Contains((def.Scope as ModuleDefinition)?.Assembly.Name.Name ?? def.Scope.Name)))
+                {
+                    return false;
+                }
+
+                return (!def.IsAbstract && (def.IsEnum || def.IsSerializable)) ||
                        DerivesFromUEObject(def) ||
-                       IsSpecialUnityType(def)); //field has a serializable type
+                       IsSpecialUnityType(def);//field has a serializable type
             }
         }
 


### PR DESCRIPTION
Unity can't serialize fields of normal abstract types (even though they can have `IsSerialized` = true), but it can serialize fields of abstract types that inherit from `UnityEngine.Object`, because it's just a PPtr<>.

In AssetsTools v2 `LoadAssetsFile` for `FileStream` was using already loaded file if there was one. In v3 it was changed and this method now loads new instance every time, which is an incorrect behavior for dependency loading, so using the one with path instead.