### PR TITLE
ManagedReferencesRegistry

### DIFF
--- a/AssetTools.NET/Extra/UnityVersion.cs
+++ b/AssetTools.NET/Extra/UnityVersion.cs
@@ -42,6 +42,10 @@ namespace AssetsTools.NET.Extra
                             break;
                         }
                     }
+                    if (newPatchNumString.Length > 0)
+                    {
+                        typeNum = int.Parse(newPatchNumString);
+                    }
                 }
             }
             else

--- a/AssetTools.NET/Extra/ValueBuilder.cs
+++ b/AssetTools.NET/Extra/ValueBuilder.cs
@@ -79,8 +79,8 @@ namespace AssetsTools.NET.Extra
                     obj = new byte[0]; break;
                 case AssetValueType.Array:
                     obj = new AssetTypeArrayInfo(); break;
-                case AssetValueType.ReferencedObject:
-                    throw new NotImplementedException("ReferencedObject is not supported by ValueBuilder yet");
+                case AssetValueType.ManagedReferencesRegistry:
+                    throw new NotImplementedException("ManagedReferencesRegistry is not supported by ValueBuilder yet");
                 default:
                     obj = null; break;
             }

--- a/AssetTools.NET/Standard/AssetTypeClass/AssetTypeTemplateField.cs
+++ b/AssetTools.NET/Standard/AssetTypeClass/AssetTypeTemplateField.cs
@@ -251,13 +251,11 @@ namespace AssetsTools.NET
                             while (true)
                             {
                                 var refdObject = MakeReferencedObject(reader, registry.version, registry.references.Count, refMan);
-                                registry.references.Add(refdObject);
-                                if (refdObject.type.ClassName == "Terminus" &&
-                                    refdObject.type.Namespace == "UnityEngine.DMAT" &&
-                                    refdObject.type.AsmName == "FAKE_ASM")
+                                if (refdObject.type.Equals(AssetTypeReference.TERMINUS))
                                 {
                                     break;
                                 }
+                                registry.references.Add(refdObject);
                             }
                         }
                         else

--- a/AssetTools.NET/Standard/AssetTypeClass/AssetTypeValue.cs
+++ b/AssetTools.NET/Standard/AssetTypeClass/AssetTypeValue.cs
@@ -73,9 +73,9 @@ namespace AssetsTools.NET
             ValueType = asString ? AssetValueType.String : AssetValueType.ByteArray;
             Value = value;
         }
-        public AssetTypeValue(AssetTypeReferencedObject value)
+        public AssetTypeValue(ManagedReferencesRegistry value)
         {
-            ValueType = AssetValueType.ReferencedObject;
+            ValueType = AssetValueType.ManagedReferencesRegistry;
             Value = value;
         }
         public AssetTypeValue(AssetValueType valueType, object value = null)
@@ -241,9 +241,9 @@ namespace AssetsTools.NET
             get => (byte[])Value;
             set => Value = value;
         }
-        public AssetTypeReferencedObject AsReferencedObject
+        public ManagedReferencesRegistry AsManagedReferencesRegistry
         {
-            get => (AssetTypeReferencedObject)Value;
+            get => (ManagedReferencesRegistry)Value;
             set => Value = value;
         }
 

--- a/AssetTools.NET/Standard/AssetTypeClass/AssetTypeValueField.cs
+++ b/AssetTools.NET/Standard/AssetTypeClass/AssetTypeValueField.cs
@@ -259,6 +259,10 @@ namespace AssetsTools.NET
                                 refdObject.type.Write(writer);
                                 refdObject.data.Write(writer);
                             }
+                            if (AsManagedReferencesRegistry.version == 1)
+                            {
+                                AssetTypeReference.TERMINUS.Write(writer);
+                            }
                             break;
                     }
                 }

--- a/AssetTools.NET/Standard/AssetTypeClass/AssetTypeValueField.cs
+++ b/AssetTools.NET/Standard/AssetTypeClass/AssetTypeValueField.cs
@@ -22,7 +22,7 @@ namespace AssetsTools.NET
 
         public bool IsDummy { get; set; }
 
-        public static readonly AssetTypeValueField DUMMY_FIELD = new AssetTypeValueField() { IsDummy = true };
+        public static readonly AssetTypeValueField DUMMY_FIELD = new AssetTypeValueField() { IsDummy = true, Children = new List<AssetTypeValueField>() };
 
         public void Read(AssetTypeValue value, AssetTypeTemplateField templateField, List<AssetTypeValueField> children)
         {
@@ -137,8 +137,8 @@ namespace AssetsTools.NET
                     return AssetValueType.Array;
                 case "TypelessData":
                     return AssetValueType.ByteArray;
-                case "ReferencedObject":
-                    return AssetValueType.ReferencedObject;
+                case "ManagedReferencesRegistry":
+                    return AssetValueType.ManagedReferencesRegistry;
                 default:
                     return AssetValueType.None;
             }
@@ -148,8 +148,7 @@ namespace AssetsTools.NET
         {
             if (TemplateField.IsArray)
             {
-                if (TemplateField.ValueType == AssetValueType.ByteArray ||
-                    TemplateField.ValueType == AssetValueType.ReferencedObject)
+                if (TemplateField.ValueType == AssetValueType.ByteArray)
                 {
                     byte[] byteArray = AsByteArray;
 
@@ -246,6 +245,21 @@ namespace AssetsTools.NET
                             writer.Write(AsByteArray);
                             writer.Align();
                             break;
+                        case AssetValueType.ManagedReferencesRegistry:
+                            writer.Write(AsManagedReferencesRegistry.version);
+                            int childCount = AsManagedReferencesRegistry.references.Count;
+                            
+                            for (int i = 0; i < childCount; i++)
+                            {
+                                AssetTypeReferencedObject refdObject = AsManagedReferencesRegistry.references[i];
+                                if (AsManagedReferencesRegistry.version == 1)
+                                {
+                                    writer.Write(refdObject.rid);
+                                }
+                                refdObject.type.Write(writer);
+                                refdObject.data.Write(writer);
+                            }
+                            break;
                     }
                 }
                 else
@@ -302,7 +316,7 @@ namespace AssetsTools.NET
         public object AsObject { get => Value.AsObject; set => Value.AsObject = value; }
         public AssetTypeArrayInfo AsArray { get => Value.AsArray; set => Value.AsArray = value; }
         public byte[] AsByteArray { get => Value.AsByteArray; set => Value.AsByteArray = value; }
-        public AssetTypeReferencedObject AsReferencedObject { get => Value.AsReferencedObject; set => Value.AsReferencedObject = value; }
+        public ManagedReferencesRegistry AsManagedReferencesRegistry { get => Value.AsManagedReferencesRegistry; set => Value.AsManagedReferencesRegistry = value; }
 
         public string TypeName { get => TemplateField.Type; }
         public string FieldName { get => TemplateField.Name; }

--- a/AssetTools.NET/Standard/AssetTypeClass/EnumValueTypes.cs
+++ b/AssetTools.NET/Standard/AssetTypeClass/EnumValueTypes.cs
@@ -17,6 +17,6 @@
         String,
         Array,
         ByteArray,
-        ReferencedObject
+        ManagedReferencesRegistry
     }
 }

--- a/AssetTools.NET/Standard/AssetTypeClass/ManagedReferencesRegistry.cs
+++ b/AssetTools.NET/Standard/AssetTypeClass/ManagedReferencesRegistry.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace AssetsTools.NET
+{
+    public class ManagedReferencesRegistry
+    {
+        public int version;
+        public List<AssetTypeReferencedObject> references;
+    }
+}

--- a/AssetTools.NET/Standard/AssetTypeClass/RefTypeManager.cs
+++ b/AssetTools.NET/Standard/AssetTypeClass/RefTypeManager.cs
@@ -27,6 +27,12 @@ namespace AssetsTools.NET
 
                 AssetTypeTemplateField templateField = new AssetTypeTemplateField();
                 templateField.FromTypeTree(type);
+                //If RefType has fields with [SerializeReference] it will contain its own registry,
+                //but it shouldn't be there, as the registry is only available at the root type
+                if (templateField.Children.Count > 0 && templateField.Children[templateField.Children.Count - 1].Type == "ManagedReferencesRegistry")
+                {
+                    templateField.Children.RemoveAt(templateField.Children.Count - 1);
+                }
 
                 lookup[type.TypeReference] = templateField;
             }

--- a/AssetTools.NET/Standard/AssetTypeClass/RefTypeManager.cs
+++ b/AssetTools.NET/Standard/AssetTypeClass/RefTypeManager.cs
@@ -7,7 +7,7 @@ namespace AssetsTools.NET
     public class RefTypeManager
     {
         private Dictionary<AssetTypeReference, AssetTypeTemplateField> lookup;
-        
+
         public RefTypeManager()
         {
             lookup = new Dictionary<AssetTypeReference, AssetTypeTemplateField>();
@@ -29,7 +29,7 @@ namespace AssetsTools.NET
                 templateField.FromTypeTree(type);
                 //If RefType has fields with [SerializeReference] it will contain its own registry,
                 //but it shouldn't be there, as the registry is only available at the root type
-                if (templateField.Children.Count > 0 && templateField.Children[templateField.Children.Count - 1].Type == "ManagedReferencesRegistry")
+                if (templateField.Children.Count > 0 && templateField.Children[templateField.Children.Count - 1].ValueType == AssetValueType.ManagedReferencesRegistry)
                 {
                     templateField.Children.RemoveAt(templateField.Children.Count - 1);
                 }
@@ -37,7 +37,7 @@ namespace AssetsTools.NET
                 lookup[type.TypeReference] = templateField;
             }
         }
-        
+
         public void FromTypeTree(AssetsFileMetadata metadata, TypeTreeType ttType)
         {
             foreach (int dep in ttType.TypeDependencies)
@@ -51,7 +51,7 @@ namespace AssetsTools.NET
                 templateField.FromTypeTree(type);
                 //If RefType has fields with [SerializeReference] it will contain its own registry,
                 //but it shouldn't be there, as the registry is only available at the root type
-                if (templateField.Children.Count > 0 && templateField.Children[templateField.Children.Count - 1].Type == "ManagedReferencesRegistry")
+                if (templateField.Children.Count > 0 && templateField.Children[templateField.Children.Count - 1].ValueType == AssetValueType.ManagedReferencesRegistry)
                 {
                     templateField.Children.RemoveAt(templateField.Children.Count - 1);
                 }

--- a/AssetTools.NET/Standard/AssetTypeClass/RefTypeManager.cs
+++ b/AssetTools.NET/Standard/AssetTypeClass/RefTypeManager.cs
@@ -43,6 +43,12 @@ namespace AssetsTools.NET
 
                 AssetTypeTemplateField templateField = new AssetTypeTemplateField();
                 templateField.FromTypeTree(type);
+                //If RefType has fields with [SerializeReference] it will contain its own registry,
+                //but it shouldn't be there, as the registry is only available at the root type
+                if (templateField.Children.Count > 0 && templateField.Children[templateField.Children.Count - 1].Type == "ManagedReferencesRegistry")
+                {
+                    templateField.Children.RemoveAt(templateField.Children.Count - 1);
+                }
 
                 lookup[type.TypeReference] = templateField;
             }

--- a/AssetTools.NET/Standard/AssetsFileFormat/AssetsTypeReference.cs
+++ b/AssetTools.NET/Standard/AssetsFileFormat/AssetsTypeReference.cs
@@ -12,6 +12,8 @@ namespace AssetsTools.NET
         public string Namespace { get; set; }
         public string AsmName { get; set; }
 
+        public static readonly AssetTypeReference TERMINUS = new AssetTypeReference("Terminus", "UnityEngine.DMAT", "FAKE_ASM");
+
         public AssetTypeReference() { }
         
         public AssetTypeReference(string className, string nameSpace, string asmName)

--- a/AssetsView/Winforms/GameObjectViewer.cs
+++ b/AssetsView/Winforms/GameObjectViewer.cs
@@ -183,8 +183,8 @@ namespace AssetsView.Winforms
         private void PopulateDataGrid(AssetTypeValueField atvf, PGProperty node, AssetFileInfo info, string category, bool arrayChildren = false)
         {
             List<AssetTypeValueField> children;
-            if (atvf.Value != null && atvf.Value.ValueType == AssetValueType.ReferencedObject)
-                children = new List<AssetTypeValueField>() { atvf.Value.AsReferencedObject.data };
+            if (atvf.Value != null && atvf.Value.ValueType == AssetValueType.ManagedReferencesRegistry)
+                children = atvf.Value.AsManagedReferencesRegistry.references.Select(r => r.data).ToList();
             else
                 children = atvf.Children;
 
@@ -192,7 +192,9 @@ namespace AssetsView.Winforms
                 return;
         
             string arrayName = string.Empty;
-            if (arrayChildren && children.Count > 0)
+            if (atvf.Value != null && atvf.Value.ValueType == AssetValueType.ManagedReferencesRegistry) 
+                arrayName = atvf.TemplateField.Name;
+            else if (arrayChildren && children.Count > 0)
                 arrayName = children[0].TemplateField.Name;
         
             for (int i = 0; i < children.Count; i++)
@@ -208,7 +210,7 @@ namespace AssetsView.Winforms
                     key = $"{arrayName}[{i}]";
         
                 AssetValueType evt;
-                if (atvfc.Value != null && atvfc.Value.ValueType != AssetValueType.ReferencedObject)
+                if (atvfc.Value != null)
                 {
                     evt = atvfc.Value.ValueType;
                     if (evt != AssetValueType.None)
@@ -238,6 +240,15 @@ namespace AssetsView.Winforms
                             prop.category = category;
                             SetSelectedStateIfSelected(info, prop);
                             node.Add(prop);
+                        }
+                        else if (evt == AssetValueType.ManagedReferencesRegistry)
+                        {
+                            PGProperty childProps = new PGProperty("child", null, $"[size: {atvfc.Value.AsManagedReferencesRegistry.references.Count}]");
+                            PGProperty prop = new PGProperty(key, childProps, $"[size: {atvfc.Value.AsManagedReferencesRegistry.references.Count}]");
+                            prop.category = category;
+                            SetSelectedStateIfSelected(info, prop);
+                            node.Add(prop);
+                            PopulateDataGrid(atvfc, childProps, info, category, true);
                         }
                     }
                 }


### PR DESCRIPTION
Before I get to implementing managed references with MonoCecilTempGenerator I decided to fix them when using TypeTree.
There are already 2 versions of the format. It's better to work on `ManagedReferencesRegistry` instead of `ReferencedObject` because version 1 didn't have `rid` field in the `ReferencedObject` and instead the `id` was the index of a `ReferencedObject` in `ManagedReferencesRegistry`. More than that, version 1 `ManagedReferencesRegistry` references field is not an array, and instead you need to read until you meet specific type value.
I took some inspiration from [UnityDataTools/PPtrReader](https://github.com/Unity-Technologies/UnityDataTools/blob/main/UnityFileSystem/TypeTreeReaders/PPtrReader.cs) but from testing it, it doesn't correctly support the case where you have a field with [SerializeReference] of a type that has a field with [SerializeReference], which is a valid case