### PR TITLE
Mono cecil generator updates

### DIFF
--- a/AssetTools.NET/Extra/AssetsManager/AssetsManager.Assets.cs
+++ b/AssetTools.NET/Extra/AssetsManager/AssetsManager.Assets.cs
@@ -72,6 +72,10 @@ namespace AssetsTools.NET.Extra
             string lookupKey = GetFileLookupKey(path);
             if (FileLookup.TryGetValue(lookupKey, out AssetsFileInstance fileInst))
             {
+                monoTypeTreeTemplateFieldCache.Remove(fileInst);
+                monoCldbTemplateFieldCache.Remove(fileInst);
+                refTypeManagerCache.Remove(fileInst);
+
                 Files.Remove(fileInst);
                 FileLookup.Remove(lookupKey);
                 fileInst.file.Close();
@@ -86,6 +90,10 @@ namespace AssetsTools.NET.Extra
 
             if (Files.Contains(fileInst))
             {
+                monoTypeTreeTemplateFieldCache.Remove(fileInst);
+                monoCldbTemplateFieldCache.Remove(fileInst);
+                refTypeManagerCache.Remove(fileInst);
+
                 string lookupKey = GetFileLookupKey(fileInst.path);
                 FileLookup.Remove(lookupKey);
                 Files.Remove(fileInst);
@@ -102,6 +110,10 @@ namespace AssetsTools.NET.Extra
                 templateFieldCache.Clear();
                 monoTemplateFieldCache.Clear();
             }
+
+            monoTypeTreeTemplateFieldCache.Clear();
+            monoCldbTemplateFieldCache.Clear();
+            refTypeManagerCache.Clear();
 
             if (Files.Count != 0)
             {

--- a/AssetTools.NET/Extra/AssetsManager/AssetsManager.Deserialization.cs
+++ b/AssetTools.NET/Extra/AssetsManager/AssetsManager.Deserialization.cs
@@ -6,28 +6,27 @@ namespace AssetsTools.NET.Extra
 {
     public partial class AssetsManager
     {
-        public RefTypeManager GetRefTypeManager(AssetsFileInstance inst, int typeId, ushort scriptIndex)
+        public RefTypeManager GetRefTypeManager(AssetsFileInstance inst)
         {
-            TypeTreeType ttType = inst.file.Metadata.FindTypeTreeTypeByID(typeId, scriptIndex);
+            if (UseRefTypeManagerCache && refTypeManagerCache.TryGetValue(inst, out RefTypeManager refMan))
+            {
+                return refMan;
+            }
+
+            refMan = new RefTypeManager();
+            refMan.FromTypeTree(inst.file.Metadata);
             
-            if (ttType == null || ttType.IsRefType)
-                return null;
+            if (MonoTempGenerator != null)
+            {
+                refMan.WithMonoTemplateGenerator(inst.file.Metadata, MonoTempGenerator, UseMonoTemplateFieldCache ? monoTemplateFieldCache : null);
+            }
 
-            if (ttType.TypeDependencies == null || ttType.TypeDependencies.Length == 0)
-                return null;
-
-            RefTypeManager refMan = new RefTypeManager();
-            refMan.FromTypeTree(inst.file.Metadata, ttType);
+            if (UseRefTypeManagerCache)
+            {
+                refTypeManagerCache[inst] = refMan;
+            }
 
             return refMan;
-        }
-
-        public RefTypeManager GetRefTypeManager(AssetsFileInstance inst, AssetFileInfo info)
-        {
-            int typeId = info.TypeId;
-            ushort scriptIndex = inst.file.GetScriptIndex(info);
-
-            return GetRefTypeManager(inst, typeId, scriptIndex);
         }
 
         public AssetTypeTemplateField GetTemplateBaseField(
@@ -44,100 +43,161 @@ namespace AssetsTools.NET.Extra
             int typeId, ushort scriptIndex, AssetReadFlags readFlags)
         {
             AssetsFile file = inst.file;
-            AssetTypeTemplateField baseField;
+            AssetTypeTemplateField baseField = null;
             bool hasTypeTree = inst.file.Metadata.TypeTreeEnabled;
 
             bool preferEditor = Net35Polyfill.HasFlag(readFlags, AssetReadFlags.PreferEditor);
             bool forceFromCldb = Net35Polyfill.HasFlag(readFlags, AssetReadFlags.ForceFromCldb);
             bool skipMonoBehaviourFields = Net35Polyfill.HasFlag(readFlags, AssetReadFlags.SkipMonoBehaviourFields);
 
-            if (UseTemplateFieldCache && templateFieldCache.ContainsKey(typeId))
+            if (UseTemplateFieldCache && typeId != (int)AssetClassID.MonoBehaviour && templateFieldCache.TryGetValue(typeId, out baseField))
             {
-                baseField = templateFieldCache[typeId];
                 return baseField;
             }
-            else
+
+            if (hasTypeTree && !forceFromCldb)
             {
-                if (hasTypeTree && !forceFromCldb)
+                if (UseMonoTemplateFieldCache && typeId == (int)AssetClassID.MonoBehaviour)
                 {
-                    TypeTreeType ttType = file.Metadata.FindTypeTreeTypeByID(typeId, scriptIndex);
-                    if (ttType != null && ttType.Nodes.Count > 0)
+                    if (monoTypeTreeTemplateFieldCache.TryGetValue(inst, out Dictionary<ushort, AssetTypeTemplateField> templates) &&
+                        templates.TryGetValue(scriptIndex, out AssetTypeTemplateField template))
                     {
-                        baseField = new AssetTypeTemplateField();
-                        baseField.FromTypeTree(ttType);
-
-                        // todo: handle monos
-                        if (UseTemplateFieldCache && typeId != (int)AssetClassID.MonoBehaviour)
-                        {
-                            templateFieldCache[typeId] = baseField;
-                        }
-
-                        return baseField;
+                        return template;
                     }
                 }
 
-                ClassDatabaseType cldbType = ClassDatabase.FindAssetClassByID(typeId);
-                if (cldbType != null)
+                TypeTreeType ttType = file.Metadata.FindTypeTreeTypeByID(typeId, scriptIndex);
+                if (ttType != null && ttType.Nodes.Count > 0)
                 {
                     baseField = new AssetTypeTemplateField();
-                    baseField.FromClassDatabase(ClassDatabase, cldbType, preferEditor);
+                    baseField.FromTypeTree(ttType);
 
-                    // todo: handle monos
                     if (UseTemplateFieldCache && typeId != (int)AssetClassID.MonoBehaviour)
                     {
                         templateFieldCache[typeId] = baseField;
                     }
-
-                    if (typeId == (int)AssetClassID.MonoBehaviour && MonoTempGenerator != null && !skipMonoBehaviourFields)
+                    else if (UseMonoTemplateFieldCache && typeId == (uint)AssetClassID.MonoBehaviour)
                     {
-                        AssetTypeValueField mbBaseField = baseField.MakeValue(reader, absByteStart);
-                        AssetPPtr msPtr = AssetPPtr.FromField(mbBaseField["m_Script"]);
-                        if (!msPtr.IsNull())
+                        if (!monoTypeTreeTemplateFieldCache.TryGetValue(inst, out Dictionary<ushort, AssetTypeTemplateField> templates))
                         {
-                            AssetsFileInstance monoScriptFile;
-                            if (msPtr.FileId == 0)
-                                monoScriptFile = inst;
-                            else
-                                monoScriptFile = inst.GetDependency(this, msPtr.FileId - 1);
-
-                            AssetFileInfo monoScriptInfo = monoScriptFile.file.GetAssetInfo(msPtr.PathId);
-                            long monoScriptAbsFilePos = monoScriptInfo.AbsoluteByteStart;
-                            int monoScriptTypeId = monoScriptInfo.TypeId;
-                            ushort monoScriptScriptIndex = monoScriptFile.file.GetScriptIndex(monoScriptInfo);
-
-                            bool success = GetMonoScriptInfo(
-                                monoScriptFile, monoScriptAbsFilePos, monoScriptTypeId, monoScriptScriptIndex,
-                                out string assemblyName, out string nameSpace, out string className, readFlags);
-
-                            // newer games don't have .dll
-                            // let's just be consistent and remove .dll from all assemblyName strings
-                            if (assemblyName.EndsWith(".dll"))
-                            {
-                                assemblyName = assemblyName.Substring(0, assemblyName.Length - 4);
-                            }
-
-                            if (success)
-                            {
-                                AssetTypeTemplateField newBaseField =
-                                    MonoTempGenerator.GetTemplateField(baseField, assemblyName, nameSpace, className, new UnityVersion(file.Metadata.UnityVersion));
-
-                                if (newBaseField != null)
-                                {
-                                    baseField = newBaseField;
-                                }
-                                else
-                                {
-                                    // failure, maybe report why?
-                                }
-                            }
+                            monoTypeTreeTemplateFieldCache[inst] = templates = new Dictionary<ushort, AssetTypeTemplateField>();
                         }
+                        templates[scriptIndex] = baseField;
                     }
 
                     return baseField;
                 }
-
-                return null;
             }
+
+            if (UseTemplateFieldCache && UseMonoTemplateFieldCache && typeId == (int)AssetClassID.MonoBehaviour)
+            {
+                if (templateFieldCache.TryGetValue(typeId, out baseField))
+                {
+                    baseField = baseField.Clone();
+                }
+            }
+
+            if (baseField == null)
+            {
+                ClassDatabaseType cldbType = ClassDatabase.FindAssetClassByID(typeId);
+                if (cldbType == null)
+                {
+                    return null;
+                }
+
+                baseField = new AssetTypeTemplateField();
+                baseField.FromClassDatabase(ClassDatabase, cldbType, preferEditor);
+
+                if (UseTemplateFieldCache)
+                {
+                    if (typeId == (int)AssetClassID.MonoBehaviour)
+                    {
+                        templateFieldCache[typeId] = baseField.Clone();
+                    }
+                    else
+                    {
+                        templateFieldCache[typeId] = baseField;
+                    }
+                }
+            }
+
+            if (typeId == (int)AssetClassID.MonoBehaviour && MonoTempGenerator != null && !skipMonoBehaviourFields)
+            {
+                AssetTypeValueField mbBaseField = baseField.MakeValue(reader, absByteStart);
+                AssetPPtr msPtr = AssetPPtr.FromField(mbBaseField["m_Script"]);
+                if (!msPtr.IsNull())
+                {
+                    AssetsFileInstance monoScriptFile;
+                    if (msPtr.FileId == 0)
+                        monoScriptFile = inst;
+                    else
+                        monoScriptFile = inst.GetDependency(this, msPtr.FileId - 1);
+
+                    Dictionary<long, AssetTypeTemplateField> templates = null;
+                    if (UseMonoTemplateFieldCache)
+                    {
+                        if (monoCldbTemplateFieldCache.TryGetValue(monoScriptFile, out templates))
+                        {
+                            if (templates.TryGetValue(msPtr.PathId, out AssetTypeTemplateField template))
+                            {
+                                return template;
+                            }
+                        }
+                        else
+                        {
+                            monoCldbTemplateFieldCache[monoScriptFile] = templates = new Dictionary<long, AssetTypeTemplateField>();
+                        }
+                    }
+
+                    AssetFileInfo monoScriptInfo = monoScriptFile.file.GetAssetInfo(msPtr.PathId);
+                    long monoScriptAbsFilePos = monoScriptInfo.AbsoluteByteStart;
+                    int monoScriptTypeId = monoScriptInfo.TypeId;
+                    ushort monoScriptScriptIndex = monoScriptFile.file.GetScriptIndex(monoScriptInfo);
+
+                    bool success = GetMonoScriptInfo(
+                        monoScriptFile, monoScriptAbsFilePos, monoScriptTypeId, monoScriptScriptIndex,
+                        out string assemblyName, out string nameSpace, out string className, readFlags);
+
+                    // newer games don't have .dll
+                    // let's just be consistent and remove .dll from all assemblyName strings
+                    if (assemblyName.EndsWith(".dll"))
+                    {
+                        assemblyName = assemblyName.Substring(0, assemblyName.Length - 4);
+                    }
+
+                    if (success)
+                    {
+                        AssetTypeReference reference = new AssetTypeReference(className, nameSpace, assemblyName);
+                        if (UseMonoTemplateFieldCache)
+                        {
+                            if (monoTemplateFieldCache.TryGetValue(reference, out AssetTypeTemplateField template))
+                            {
+                                templates[msPtr.PathId] = template;
+                                return template;
+                            }
+                        }
+
+                        AssetTypeTemplateField newBaseField =
+                            MonoTempGenerator.GetTemplateField(baseField, assemblyName, nameSpace, className, new UnityVersion(file.Metadata.UnityVersion));
+
+                        if (newBaseField != null)
+                        {
+                            baseField = newBaseField;
+                            if (UseMonoTemplateFieldCache)
+                            {
+                                templates[msPtr.PathId] = monoTemplateFieldCache[reference] = baseField;
+                                return baseField;
+                            }
+                        }
+                        else
+                        {
+                            // failure, maybe report why?
+                        }
+                    }
+                }
+            }
+
+            return baseField;
         }
 
         private bool GetMonoScriptInfo(

--- a/AssetTools.NET/Extra/AssetsManager/AssetsManager.Resolving.cs
+++ b/AssetTools.NET/Extra/AssetsManager/AssetsManager.Resolving.cs
@@ -66,7 +66,7 @@ namespace AssetsTools.NET.Extra
         public AssetTypeValueField GetBaseField(AssetsFileInstance inst, AssetFileInfo info, AssetReadFlags readFlags = AssetReadFlags.None)
         {
             AssetTypeTemplateField tempField = GetTemplateBaseField(inst, info, readFlags);
-            RefTypeManager refMan = GetRefTypeManager(inst, info);
+            RefTypeManager refMan = GetRefTypeManager(inst);
             AssetTypeValueField valueField = tempField.MakeValue(inst.file.Reader, info.AbsoluteByteStart, refMan);
             return valueField;
         }
@@ -74,10 +74,7 @@ namespace AssetsTools.NET.Extra
         public AssetTypeValueField GetBaseField(AssetsFileInstance inst, long pathId, AssetReadFlags readFlags = AssetReadFlags.None)
         {
             AssetFileInfo info = inst.file.GetAssetInfo(pathId);
-            AssetTypeTemplateField tempField = GetTemplateBaseField(inst, info, readFlags);
-            RefTypeManager refMan = GetRefTypeManager(inst, info);
-            AssetTypeValueField valueField = tempField.MakeValue(inst.file.Reader, info.AbsoluteByteStart, refMan);
-            return valueField;
+            return GetBaseField(inst, info, readFlags);
         }
     }
 }

--- a/AssetTools.NET/Extra/AssetsManager/AssetsManager.cs
+++ b/AssetTools.NET/Extra/AssetsManager/AssetsManager.cs
@@ -12,6 +12,8 @@ namespace AssetsTools.NET.Extra
     {
         public bool UpdateAfterLoad { get; set; } = true;
         public bool UseTemplateFieldCache { get; set; } = false;
+        public bool UseMonoTemplateFieldCache { get; set; } = false;
+        public bool UseRefTypeManagerCache { get; set; } = false;
 
         public ClassDatabaseFile ClassDatabase { get; private set; }
         public ClassPackageFile ClassPackage { get; private set; }
@@ -25,7 +27,10 @@ namespace AssetsTools.NET.Extra
         public IMonoBehaviourTemplateGenerator MonoTempGenerator { get; set; } = null;
 
         private readonly Dictionary<int, AssetTypeTemplateField> templateFieldCache = new Dictionary<int, AssetTypeTemplateField>();
-        private readonly Dictionary<string, AssetTypeTemplateField> monoTemplateFieldCache = new Dictionary<string, AssetTypeTemplateField>();
+        private readonly Dictionary<AssetTypeReference, AssetTypeTemplateField> monoTemplateFieldCache = new Dictionary<AssetTypeReference, AssetTypeTemplateField>();
+        private readonly Dictionary<AssetsFileInstance, Dictionary<ushort, AssetTypeTemplateField>> monoTypeTreeTemplateFieldCache = new Dictionary<AssetsFileInstance, Dictionary<ushort, AssetTypeTemplateField>>();
+        private readonly Dictionary<AssetsFileInstance, Dictionary<long, AssetTypeTemplateField>> monoCldbTemplateFieldCache = new Dictionary<AssetsFileInstance, Dictionary<long, AssetTypeTemplateField>>();
+        private readonly Dictionary<AssetsFileInstance, RefTypeManager> refTypeManagerCache = new Dictionary<AssetsFileInstance, RefTypeManager>();
 
         public void UnloadAll(bool unloadClassData = false)
         {

--- a/AssetTools.NET/Extra/MonoDeserializer/CommonMonoTemplateHelper.cs
+++ b/AssetTools.NET/Extra/MonoDeserializer/CommonMonoTemplateHelper.cs
@@ -16,16 +16,23 @@ namespace AssetsTools.NET.Extra
         private static readonly string[] blacklistedAssemblies = new[]
         {
             "mscorlib",
+            "mscorlib.dll",
             "netstandard",
+            "netstandard.dll",
             "System.Core",
+            "System.Core.dll",
             "System",
+            "System.dll",
 
             //Got these when testing assembly directly from Library\ScriptAssemblies
             //Discovered from dotnet by cecil because it couldn't find system libs in the same folder as assembly
             //Should be safe to also exclude them
             "System.Private.CoreLib",
+            "System.Private.CoreLib.dll",
             "System.Collections",
-            "System.Collections.NonGeneric"
+            "System.Collections.dll",
+            "System.Collections.NonGeneric",
+            "System.Collections.NonGeneric.dll"
         };
 
         private static readonly string[] specialUnityTypes = new[]
@@ -47,6 +54,22 @@ namespace AssetsTools.NET.Extra
             "UnityEngine.Vector2Int",
             "UnityEngine.Vector3Int",
             "UnityEngine.BoundsInt"
+        };
+
+        private static readonly string[] primitiveTypes = new[]
+        {
+            "System.Boolean",
+            "System.SByte",
+            "System.Byte",
+            "System.Char",
+            "System.Int16",
+            "System.UInt16",
+            "System.Int32",
+            "System.UInt32",
+            "System.Int64",
+            "System.UInt64",
+            "System.Double",
+            "System.Single"
         };
 
         private static readonly Dictionary<string, string> baseToPrimitive = new Dictionary<string, string>()
@@ -116,6 +139,11 @@ namespace AssetsTools.NET.Extra
             return blacklistedAssemblies.Contains(assembly);
         }
 
+        public static bool IsPrimitiveType(string fullName)
+        {
+            return primitiveTypes.Contains(fullName);
+        }
+
         public static bool TypeAligns(AssetValueType valueType)
         {
             if (valueType.Equals(AssetValueType.Bool) ||
@@ -125,6 +153,18 @@ namespace AssetsTools.NET.Extra
                 valueType.Equals(AssetValueType.UInt16))
                 return true;
             return false;
+        }
+
+        public static int GetSerializationLimit(UnityVersion unityVersion)
+        {
+            if (unityVersion.major > 2020 ||
+                (unityVersion.major == 2020 && (unityVersion.minor >= 2 || (unityVersion.minor == 1 && unityVersion.patch >= 4))) ||
+                (unityVersion.major == 2019 && unityVersion.minor == 4 && unityVersion.patch >= 9))
+            {
+                return 10;
+            }
+
+            return 7;
         }
 
         #endregion

--- a/AssetTools.NET/Extra/MonoDeserializer/CommonMonoTemplateHelper.cs
+++ b/AssetTools.NET/Extra/MonoDeserializer/CommonMonoTemplateHelper.cs
@@ -1,0 +1,417 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace AssetsTools.NET.Extra
+{
+    public static class CommonMonoTemplateHelper
+    {
+        #region Collections
+
+        //Unity definitly excludes some assemblies from being serialized
+        //but I couldn't find the definitive list, plus it changes from version-to-version
+        //Those should be enough for most cases
+        //but need more research when it will cause problems for some games
+        private static readonly string[] blacklistedAssemblies = new[]
+        {
+            "mscorlib",
+            "netstandard",
+            "System.Core",
+            "System",
+
+            //Got these when testing assembly directly from Library\ScriptAssemblies
+            //Discovered from dotnet by cecil because it couldn't find system libs in the same folder as assembly
+            //Should be safe to also exclude them
+            "System.Private.CoreLib",
+            "System.Collections",
+            "System.Collections.NonGeneric"
+        };
+
+        private static readonly string[] specialUnityTypes = new[]
+        {
+            "UnityEngine.Color",
+            "UnityEngine.Color32",
+            "UnityEngine.Gradient",
+            "UnityEngine.Vector2",
+            "UnityEngine.Vector3",
+            "UnityEngine.Vector4",
+            "UnityEngine.LayerMask",
+            "UnityEngine.Quaternion",
+            "UnityEngine.Bounds",
+            "UnityEngine.Rect",
+            "UnityEngine.RectOffset",
+            "UnityEngine.Matrix4x4",
+            "UnityEngine.AnimationCurve",
+            "UnityEngine.GUIStyle",
+            "UnityEngine.Vector2Int",
+            "UnityEngine.Vector3Int",
+            "UnityEngine.BoundsInt"
+        };
+
+        private static readonly Dictionary<string, string> baseToPrimitive = new Dictionary<string, string>()
+        {
+            ["System.Boolean"] = "UInt8",
+            ["System.SByte"] = "SInt8",
+            ["System.Byte"] = "UInt8",
+            ["System.Char"] = "UInt16",
+            ["System.Int16"] = "SInt16",
+            ["System.UInt16"] = "UInt16",
+            ["System.Int32"] = "int",
+            ["System.UInt32"] = "unsigned int",
+            ["System.Int64"] = "SInt64",
+            ["System.UInt64"] = "UInt64",
+            ["System.Double"] = "double",
+            ["System.Single"] = "float",
+            ["System.String"] = "string"
+        };
+
+        private static readonly Dictionary<string, AssetValueType> baseToAssetValueType = new Dictionary<string, AssetValueType>()
+        {
+            ["System.Boolean"] = AssetValueType.Bool,
+            ["System.SByte"] = AssetValueType.Int8,
+            ["System.Byte"] = AssetValueType.UInt8,
+            ["System.Char"] = AssetValueType.UInt16,
+            ["System.Int16"] = AssetValueType.Int16,
+            ["System.UInt16"] = AssetValueType.UInt16,
+            ["System.Int32"] = AssetValueType.Int32,
+            ["System.UInt32"] = AssetValueType.UInt32,
+            ["System.Int64"] = AssetValueType.Int64,
+            ["System.UInt64"] = AssetValueType.UInt64,
+            ["System.Double"] = AssetValueType.Double,
+            ["System.Single"] = AssetValueType.Float,
+            ["System.String"] = AssetValueType.String
+        };
+
+        #endregion
+
+        #region Checks
+
+
+        public static string ConvertBaseToPrimitive(string name)
+        {
+            if (baseToPrimitive.TryGetValue(name, out string primitiveName))
+            {
+                return primitiveName;
+            }
+            return name;
+        }
+
+        public static AssetValueType ConvertBaseToAssetValueType(string name)
+        {
+            if (baseToAssetValueType.TryGetValue(name, out AssetValueType value))
+            {
+                return value;
+            }
+            return AssetValueType.None;
+        }
+
+        public static bool IsSpecialUnityType(string fullName)
+        {
+            return specialUnityTypes.Contains(fullName);
+        }
+
+        public static bool IsAssemblyBlacklisted(string assembly, UnityVersion unityVersion)
+        {
+            return blacklistedAssemblies.Contains(assembly);
+        }
+
+        public static bool TypeAligns(AssetValueType valueType)
+        {
+            if (valueType.Equals(AssetValueType.Bool) ||
+                valueType.Equals(AssetValueType.Int8) ||
+                valueType.Equals(AssetValueType.UInt8) ||
+                valueType.Equals(AssetValueType.Int16) ||
+                valueType.Equals(AssetValueType.UInt16))
+                return true;
+            return false;
+        }
+
+        #endregion
+
+        #region Basic types
+
+        public static AssetTypeTemplateField Bool(string name, bool align = false) => CreateTemplateField(name, "bool", AssetValueType.Bool, false, align);
+        public static AssetTypeTemplateField SByte(string name, bool align = false) => CreateTemplateField(name, "SInt8", AssetValueType.Int8, false, align);
+        public static AssetTypeTemplateField Byte(string name, bool align = false) => CreateTemplateField(name, "UInt8", AssetValueType.UInt8, false, align);
+        public static AssetTypeTemplateField CChar(string name, bool align = false) => CreateTemplateField(name, "char", AssetValueType.UInt8, false, align);
+        public static AssetTypeTemplateField Char(string name, bool align = false) => CreateTemplateField(name, "UInt16", AssetValueType.UInt16, false, align);
+        public static AssetTypeTemplateField Short(string name, bool align = false) => CreateTemplateField(name, "SInt16", AssetValueType.Int16, false, align);
+        public static AssetTypeTemplateField UShort(string name, bool align = false) => CreateTemplateField(name, "UInt16", AssetValueType.UInt16, false, align);
+        public static AssetTypeTemplateField Int(string name) => CreateTemplateField(name, "int", AssetValueType.Int32);
+        public static AssetTypeTemplateField UInt(string name) => CreateTemplateField(name, "unsigned int", AssetValueType.UInt32);
+        public static AssetTypeTemplateField Long(string name) => CreateTemplateField(name, "SInt64", AssetValueType.Int64);
+        public static AssetTypeTemplateField ULong(string name) => CreateTemplateField(name, "UInt64", AssetValueType.UInt64);
+        public static AssetTypeTemplateField Float(string name) => CreateTemplateField(name, "float", AssetValueType.Float);
+        public static AssetTypeTemplateField Double(string name) => CreateTemplateField(name, "double", AssetValueType.Double);
+        
+        public static AssetTypeTemplateField String(string name)
+        {
+            return CreateTemplateField(name, "string", AssetValueType.String, String());
+        }
+
+        public static List<AssetTypeTemplateField> String()
+        {
+            return Array(CChar("data"));
+        }
+
+        public static AssetTypeTemplateField Vector(AssetTypeTemplateField field)
+        {
+            return CreateTemplateField(field.Name, "vector", Array(field));
+        }
+
+        public static AssetTypeTemplateField VectorWithType(AssetTypeTemplateField field)
+        {
+            return CreateTemplateField(field.Name, field.Type, Array(field));
+        }
+
+        public static List<AssetTypeTemplateField> Array(AssetTypeTemplateField field)
+        {
+            AssetTypeTemplateField array = new AssetTypeTemplateField
+            {
+                Name = "Array",
+                Type = "Array",
+                ValueType = field.ValueType == AssetValueType.UInt8 ? AssetValueType.ByteArray : AssetValueType.Array,
+                IsArray = true,
+                IsAligned = true,
+                HasValue = true,
+                Children = new List<AssetTypeTemplateField>
+                {
+                    Int("size"), CreateTemplateField("data", field.Type, field.ValueType, field.Children)
+                }
+            };
+
+            return new List<AssetTypeTemplateField> { array };
+        }
+
+        #endregion
+
+        #region ManagedReferencesRegistry
+
+        public static AssetTypeTemplateField ManagedReference(string name, UnityVersion unityVersion) => CreateTemplateField(name, "managedReference", ManagedReference(unityVersion));
+        public static List<AssetTypeTemplateField> ManagedReference(UnityVersion unityVersion)
+        {
+            if (unityVersion.major > 2021 || (unityVersion.major == 2021 && unityVersion.minor >= 2))
+            {
+                return new List<AssetTypeTemplateField> { Long("rid") };
+            }
+
+            return new List<AssetTypeTemplateField> { Int("id") };
+        }
+
+        public static AssetTypeTemplateField ManagedReferencesRegistry(string name, UnityVersion unityVersion) =>
+            CreateTemplateField(name, "ManagedReferencesRegistry", AssetValueType.ManagedReferencesRegistry, ManagedReferencesRegistry(unityVersion));
+        public static List<AssetTypeTemplateField> ManagedReferencesRegistry(UnityVersion unityVersion)
+        {
+            if (unityVersion.major > 2021 || (unityVersion.major == 2021 && unityVersion.minor >= 2))
+            {
+                return new List<AssetTypeTemplateField> { Int("version"), Vector(ReferencedObject("RefIds", unityVersion)) };
+            }
+
+            return new List<AssetTypeTemplateField> { Int("version"), ReferencedObject("00000000", unityVersion) };
+        }
+
+        public static AssetTypeTemplateField ReferencedObject(string name, UnityVersion unityVersion) => CreateTemplateField(name, "ReferencedObject", ReferencedObject(unityVersion));
+        public static List<AssetTypeTemplateField> ReferencedObject(UnityVersion unityVersion)
+        {
+            if (unityVersion.major > 2021 || (unityVersion.major == 2021 && unityVersion.minor >= 2))
+            {
+                return new List<AssetTypeTemplateField> { Long("rid"), ReferencedManagedType("type"), CreateTemplateField("data", "ReferencedObjectData", AssetValueType.None) };
+            }
+
+            return new List<AssetTypeTemplateField> { ReferencedManagedType("type"), CreateTemplateField("data", "ReferencedObjectData", AssetValueType.None) };
+        }
+
+        public static AssetTypeTemplateField ReferencedManagedType(string name) => CreateTemplateField(name, "ReferencedManagedType", ReferencedManagedType());
+        public static List<AssetTypeTemplateField> ReferencedManagedType()
+        {
+            return new List<AssetTypeTemplateField> { String("class"), String("ns"), String("asm") };
+        }
+
+        #endregion
+
+        #region Special Unity types
+
+        public static AssetTypeTemplateField Gradient(string name, UnityVersion unityVersion) => CreateTemplateField(name, "Gradient", Gradient(unityVersion));
+        public static List<AssetTypeTemplateField> Gradient(UnityVersion unityVersion)
+        {
+            if (unityVersion.major > 2022 || (unityVersion.major == 2022 && unityVersion.minor >= 2))
+            {
+                return new List<AssetTypeTemplateField> {
+                    RGBAf("key0"), RGBAf("key1"), RGBAf("key2"), RGBAf("key3"), RGBAf("key4"), RGBAf("key5"), RGBAf("key6"), RGBAf("key7"),
+                    UShort("ctime0"), UShort("ctime1"), UShort("ctime2"), UShort("ctime3"), UShort("ctime4"), UShort("ctime5"), UShort("ctime6"), UShort("ctime7"),
+                    UShort("atime0"), UShort("atime1"), UShort("atime2"), UShort("atime3"), UShort("atime4"), UShort("atime5"), UShort("atime6"), UShort("atime7"),
+                    Byte("m_Mode"), SByte("m_ColorSpace"), Byte("m_NumColorKeys"), Byte("m_NumAlphaKeys", true)
+                };
+            }
+
+            return new List<AssetTypeTemplateField> {
+                RGBAf("key0"), RGBAf("key1"), RGBAf("key2"), RGBAf("key3"), RGBAf("key4"), RGBAf("key5"), RGBAf("key6"), RGBAf("key7"),
+                UShort("ctime0"), UShort("ctime1"), UShort("ctime2"), UShort("ctime3"), UShort("ctime4"), UShort("ctime5"), UShort("ctime6"), UShort("ctime7"),
+                UShort("atime0"), UShort("atime1"), UShort("atime2"), UShort("atime3"), UShort("atime4"), UShort("atime5"), UShort("atime6"), UShort("atime7"),
+                Int("m_Mode"), Byte("m_NumColorKeys"), Byte("m_NumAlphaKeys", true)
+            };
+        }
+
+        public static AssetTypeTemplateField AnimationCurve(string name, UnityVersion unityVersion) => CreateTemplateField(name, "AnimationCurve", AnimationCurve(unityVersion));
+        public static List<AssetTypeTemplateField> AnimationCurve(UnityVersion unityVersion)
+        {
+            return new List<AssetTypeTemplateField> {
+                Vector(Keyframe("m_Curve", unityVersion)), Int("m_PreInfinity"), Int("m_PostInfinity"), Int("m_RotationOrder")
+            };
+        }
+
+        //only supports 2019 right now
+        public static AssetTypeTemplateField GUIStyle(string name, UnityVersion unityVersion) => CreateTemplateField(name, "GUIStyle", GUIStyle(unityVersion));
+        public static List<AssetTypeTemplateField> GUIStyle(UnityVersion unityVersion)
+        {
+            return new List<AssetTypeTemplateField> {
+                String("m_Name"),
+                GUIStyleState("m_Normal", unityVersion), GUIStyleState("m_Hover", unityVersion), GUIStyleState("m_Active", unityVersion), GUIStyleState("m_Focused", unityVersion),
+                GUIStyleState("m_OnNormal", unityVersion), GUIStyleState("m_OnHover", unityVersion), GUIStyleState("m_OnActive", unityVersion), GUIStyleState("m_OnFocused", unityVersion),
+                RectOffset("m_Border"), RectOffset("m_Margin"), RectOffset("m_Padding"), RectOffset("m_Overflow"),
+                PPtr("m_Font", "Font", unityVersion), Int("m_FontSize"), Int("m_FontStyle"),
+                Int("m_Alignment"), Bool("m_WordWrap"), Bool("m_RichText", true),
+                Int("m_TextClipping"), Int("m_ImagePosition"), Vector2f("m_ContentOffset"),
+                Float("m_FixedWidth"), Float("m_FixedHeight"), Bool("m_StretchWidth"), Bool("m_StretchHeight", true)
+            };
+        }
+
+        public static AssetTypeTemplateField Keyframe(string name, UnityVersion unityVersion) => CreateTemplateField(name, "Keyframe", Keyframe(unityVersion));
+        public static List<AssetTypeTemplateField> Keyframe(UnityVersion unityVersion)
+        {
+            if (unityVersion.major >= 2018)
+            {
+                return new List<AssetTypeTemplateField> {
+                    Float("time"), Float("value"), Float("inSlope"), Float("outSlope"),
+                    Int("weightedMode"), Float("inWeight"), Float("outWeight")
+                };
+            }
+            return new List<AssetTypeTemplateField> { Float("time"), Float("value"), Float("inSlope"), Float("outSlope") };
+        }
+
+        public static AssetTypeTemplateField GUIStyleState(string name, UnityVersion unityVersion) => CreateTemplateField(name, "GUIStyleState", GUIStyleState(unityVersion));
+        public static List<AssetTypeTemplateField> GUIStyleState(UnityVersion unityVersion)
+        {
+            return new List<AssetTypeTemplateField> { PPtr("m_Background", "Texture2D", unityVersion), RGBAf("m_TextColor") };
+        }
+
+        public static AssetTypeTemplateField RGBAf(string name) => CreateTemplateField(name, "ColorRGBA", RGBAf());
+        public static List<AssetTypeTemplateField> RGBAf()
+        {
+            return new List<AssetTypeTemplateField> { Float("r"), Float("g"), Float("b"), Float("a") };
+        }
+
+        public static AssetTypeTemplateField RGBAi(string name) => CreateTemplateField(name, "ColorRGBA", RGBAi());
+        public static List<AssetTypeTemplateField> RGBAi()
+        {
+            return new List<AssetTypeTemplateField> { UInt("rgba") };
+        }
+
+        public static AssetTypeTemplateField AABB(string name) => CreateTemplateField(name, "AABB", AABB());
+        public static List<AssetTypeTemplateField> AABB()
+        {
+            return new List<AssetTypeTemplateField> { Vector3f("m_Center"), Vector3f("m_Extent") };
+        }
+
+        public static AssetTypeTemplateField BoundsInt(string name) => CreateTemplateField(name, "BoundsInt", BoundsInt());
+        public static List<AssetTypeTemplateField> BoundsInt()
+        {
+            return new List<AssetTypeTemplateField> { Vector3Int("m_Position"), Vector3Int("m_Size") };
+        }
+
+        public static AssetTypeTemplateField BitField(string name) => CreateTemplateField(name, "BitField", BitField());
+        public static List<AssetTypeTemplateField> BitField()
+        {
+            return new List<AssetTypeTemplateField> { UInt("m_Bits") };
+        }
+
+        public static AssetTypeTemplateField Rectf(string name) => CreateTemplateField(name, "Rectf", Rectf());
+        public static List<AssetTypeTemplateField> Rectf()
+        {
+            return new List<AssetTypeTemplateField> { Float("x"), Float("y"), Float("width"), Float("height") };
+        }
+
+        public static AssetTypeTemplateField RectOffset(string name) => CreateTemplateField(name, "RectOffset", RectOffset());
+        public static List<AssetTypeTemplateField> RectOffset()
+        {
+            return new List<AssetTypeTemplateField> { Int("m_Left"), Int("m_Right"), Int("m_Top"), Int("m_Bottom") };
+        }
+
+        public static AssetTypeTemplateField Vector2Int(string name) => CreateTemplateField(name, "int2_storage", Vector2Int());
+        public static List<AssetTypeTemplateField> Vector2Int()
+        {
+            return new List<AssetTypeTemplateField> { Int("x"), Int("y") };
+        }
+
+        public static AssetTypeTemplateField Vector3Int(string name) => CreateTemplateField(name, "int3_storage", Vector3Int());
+        public static List<AssetTypeTemplateField> Vector3Int()
+        {
+            return new List<AssetTypeTemplateField> { Int("x"), Int("y"), Int("z") };
+        }
+
+        public static AssetTypeTemplateField Vector2f(string name) => CreateTemplateField(name, "Vector2f", Vector2f());
+        public static List<AssetTypeTemplateField> Vector2f()
+        {
+            return new List<AssetTypeTemplateField> { Float("x"), Float("y") };
+        }
+
+        public static AssetTypeTemplateField Vector3f(string name) => CreateTemplateField(name, "Vector3f", Vector3f());
+        public static List<AssetTypeTemplateField> Vector3f()
+        {
+            return new List<AssetTypeTemplateField> { Float("x"), Float("y"), Float("z") };
+        }
+
+        public static AssetTypeTemplateField PPtr(string name, string typeName, UnityVersion unityVersion) => CreateTemplateField(name, $"PPtr<{typeName}>", PPtr(unityVersion));
+        public static List<AssetTypeTemplateField> PPtr(UnityVersion unityVersion)
+        {
+            if (unityVersion.major >= 5)
+            {
+                return new List<AssetTypeTemplateField> { Int("m_FileID"), Long("m_PathID") };
+            }
+
+            return new List<AssetTypeTemplateField> { Int("m_FileID"), Int("m_PathID") };
+        }
+
+        #endregion
+
+        #region CreateTemplateField
+
+        public static AssetTypeTemplateField CreateTemplateField(string name, string type, List<AssetTypeTemplateField> children)
+        {
+            return CreateTemplateField(name, type, AssetValueType.None, false, false, children);
+        }
+        public static AssetTypeTemplateField CreateTemplateField(string name, string type, AssetValueType valueType)
+        {
+            return CreateTemplateField(name, type, valueType, false, false, new List<AssetTypeTemplateField>(0));
+        }
+
+        public static AssetTypeTemplateField CreateTemplateField(string name, string type, AssetValueType valueType, bool isArray, bool align)
+        {
+            return CreateTemplateField(name, type, valueType, isArray, align, new List<AssetTypeTemplateField>(0));
+        }
+
+        public static AssetTypeTemplateField CreateTemplateField(string name, string type, AssetValueType valueType, List<AssetTypeTemplateField> children)
+        {
+            return CreateTemplateField(name, type, valueType, false, false, children);
+        }
+
+        public static AssetTypeTemplateField CreateTemplateField(string name, string type, AssetValueType valueType, bool isArray, bool align, List<AssetTypeTemplateField> children)
+        {
+            AssetTypeTemplateField field = new AssetTypeTemplateField
+            {
+                Name = name,
+                Type = type,
+                ValueType = valueType,
+                IsArray = isArray,
+                IsAligned = align,
+                HasValue = valueType != AssetValueType.None,
+                Children = children ?? new List<AssetTypeTemplateField>(0)
+            };
+
+            return field;
+        }
+
+        #endregion
+    }
+}

--- a/AssetTools.NET/Extra/MonoDeserializer/TypeDefWithSelfRef.cs
+++ b/AssetTools.NET/Extra/MonoDeserializer/TypeDefWithSelfRef.cs
@@ -35,7 +35,6 @@ namespace AssetsTools.NET.Extra
                     }
                 }
             }
-
         }
 
         public void AssignTypeParams(TypeDefWithSelfRef parentTypeDef)
@@ -52,7 +51,6 @@ namespace AssetsTools.NET.Extra
                             typeParamToArg[typeDef.GenericParameters[i].Name] = mappedType;
                         }
                     }
-
                 }
             }
         }

--- a/AssetTools.NET/Extra/ValueBuilder.cs
+++ b/AssetTools.NET/Extra/ValueBuilder.cs
@@ -80,7 +80,7 @@ namespace AssetsTools.NET.Extra
                 case AssetValueType.Array:
                     obj = new AssetTypeArrayInfo(); break;
                 case AssetValueType.ManagedReferencesRegistry:
-                    throw new NotImplementedException("ManagedReferencesRegistry is not supported by ValueBuilder yet");
+                    obj = new ManagedReferencesRegistry(); break;
                 default:
                     obj = null; break;
             }

--- a/AssetTools.NET/Standard/AssetTypeClass/AssetTypeTemplateField.cs
+++ b/AssetTools.NET/Standard/AssetTypeClass/AssetTypeTemplateField.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Security.Cryptography;
 
 namespace AssetsTools.NET
@@ -323,6 +324,21 @@ namespace AssetsTools.NET
 
             }
             return valueField;
+        }
+
+        public AssetTypeTemplateField Clone()
+        {
+            var clone = new AssetTypeTemplateField
+            {
+                Name = Name,
+                Type = Type,
+                ValueType = ValueType,
+                IsArray = IsArray,
+                IsAligned = IsAligned,
+                HasValue = HasValue,
+                Children = Children.Select(c => c.Clone()).ToList()
+            };
+            return clone;
         }
 
         private AssetTypeReferencedObject MakeReferencedObject(AssetsFileReader reader, int registryVersion, int referenceIndex, RefTypeManager refMan)

--- a/AssetTools.NET/Standard/AssetTypeClass/AssetTypeTemplateField.cs
+++ b/AssetTools.NET/Standard/AssetTypeClass/AssetTypeTemplateField.cs
@@ -238,6 +238,7 @@ namespace AssetsTools.NET
                         if (refMan == null)
                             throw new Exception("refMan MUST be set to deserialize objects with ref types!");
 
+                        valueField.Children = new List<AssetTypeValueField>(0);
                         ManagedReferencesRegistry registry = new ManagedReferencesRegistry();
                         valueField.Value = new AssetTypeValue(registry);
                         int registryChildCount = valueField.TemplateField.Children.Count;

--- a/AssetTools.NET/Standard/AssetTypeClass/AssetTypeValueField.cs
+++ b/AssetTools.NET/Standard/AssetTypeClass/AssetTypeValueField.cs
@@ -34,7 +34,7 @@ namespace AssetsTools.NET
                 ValueType = AssetValueType.None,
                 Children = new List<AssetTypeTemplateField>(0)
             },
-            Value = new AssetTypeValue(AssetValueType.None),
+            Value = null,
             IsDummy = true,
             Children = new List<AssetTypeValueField>(0)
         };

--- a/AssetTools.NET/Standard/AssetTypeClass/AssetTypeValueField.cs
+++ b/AssetTools.NET/Standard/AssetTypeClass/AssetTypeValueField.cs
@@ -22,7 +22,22 @@ namespace AssetsTools.NET
 
         public bool IsDummy { get; set; }
 
-        public static readonly AssetTypeValueField DUMMY_FIELD = new AssetTypeValueField() { IsDummy = true, Children = new List<AssetTypeValueField>() };
+        public static readonly AssetTypeValueField DUMMY_FIELD = new AssetTypeValueField()
+        {
+            TemplateField = new AssetTypeTemplateField
+            {
+                Name = "DUMMY",
+                HasValue = false,
+                IsAligned = false,
+                IsArray = false,
+                Type = "DUMMY",
+                ValueType = AssetValueType.None,
+                Children = new List<AssetTypeTemplateField>(0)
+            },
+            Value = new AssetTypeValue(AssetValueType.None),
+            IsDummy = true,
+            Children = new List<AssetTypeValueField>(0)
+        };
 
         public void Read(AssetTypeValue value, AssetTypeTemplateField templateField, List<AssetTypeValueField> children)
         {
@@ -253,16 +268,16 @@ namespace AssetsTools.NET
                             for (int i = 0; i < childCount; i++)
                             {
                                 AssetTypeReferencedObject refdObject = AsManagedReferencesRegistry.references[i];
-                                if (AsManagedReferencesRegistry.version == 1)
+                                if (AsManagedReferencesRegistry.version != 1)
                                 {
                                     writer.Write(refdObject.rid);
                                 }
-                                refdObject.type.Write(writer);
+                                refdObject.type.WriteAsset(writer);
                                 refdObject.data.Write(writer);
                             }
                             if (AsManagedReferencesRegistry.version == 1)
                             {
-                                AssetTypeReference.TERMINUS.Write(writer);
+                                AssetTypeReference.TERMINUS.WriteAsset(writer);
                             }
                             break;
                     }

--- a/AssetTools.NET/Standard/AssetsFileFormat/AssetsTypeReference.cs
+++ b/AssetTools.NET/Standard/AssetsFileFormat/AssetsTypeReference.cs
@@ -37,11 +37,18 @@ namespace AssetsTools.NET
             AsmName = reader.ReadCountStringInt32(); reader.Align();
         }
 
-        public void Write(AssetsFileWriter writer)
+        public void WriteMetadata(AssetsFileWriter writer)
         {
             writer.WriteNullTerminated(ClassName);
             writer.WriteNullTerminated(Namespace);
             writer.WriteNullTerminated(AsmName);
+        }
+
+        public void WriteAsset(AssetsFileWriter writer)
+        {
+            writer.WriteCountStringInt32(ClassName); writer.Align();
+            writer.WriteCountStringInt32(Namespace); writer.Align();
+            writer.WriteCountStringInt32(AsmName); writer.Align();
         }
 
         public override bool Equals(object obj)

--- a/AssetTools.NET/Standard/AssetsFileFormat/TypeTreeType.cs
+++ b/AssetTools.NET/Standard/AssetsFileFormat/TypeTreeType.cs
@@ -151,7 +151,7 @@ namespace AssetsTools.NET
                     }
                     else
                     {
-                        TypeReference.Write(writer);
+                        TypeReference.WriteMetadata(writer);
                     }
                 }
             }

--- a/AssetsTools.NET.Cpp2IL/AssetsTools.NET.Cpp2IL.csproj
+++ b/AssetsTools.NET.Cpp2IL/AssetsTools.NET.Cpp2IL.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <LangVersion>8</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/AssetsTools.NET.Cpp2IL/Extensions.cs
+++ b/AssetsTools.NET.Cpp2IL/Extensions.cs
@@ -1,0 +1,30 @@
+﻿using LibCpp2IL.Metadata;
+using LibCpp2IL.Reflection;
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Text;
+
+namespace AssetsTools.NET.Cpp2IL
+{
+    public static class Extensions
+    {
+        public static Il2CppTypeDefinition Resolve(this Il2CppTypeReflectionData typeRef)
+        {
+            return typeRef.isArray ? Resolve(typeRef.arrayType) : typeRef.baseType;
+        }
+
+        public static Il2CppTypeReflectionData GetEnumUnderlyingType(this Il2CppTypeDefinition self)
+        {
+            for (int i = 0; i < self.Fields.Length; i++)
+            {
+                if (!self.FieldAttributes[i].HasFlag(FieldAttributes.Static))
+                {
+                    return self.Fields[i].FieldType;
+                }
+            }
+
+            throw new ArgumentException();
+        }
+    }
+}

--- a/AssetsTools.NET.Cpp2IL/TypeDefWithSelfRef.cs
+++ b/AssetsTools.NET.Cpp2IL/TypeDefWithSelfRef.cs
@@ -1,0 +1,85 @@
+﻿using LibCpp2IL.Metadata;
+using LibCpp2IL.Reflection;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace AssetsTools.NET.Cpp2IL
+{
+    internal struct TypeDefWithSelfRef
+    {
+        public Il2CppTypeReflectionData typeRef;
+        public Il2CppTypeDefinition typeDef;
+
+        public Dictionary<string, TypeDefWithSelfRef> typeParamToArg;
+        public string[] paramNames;
+
+        public TypeDefWithSelfRef(Il2CppTypeReflectionData typeRef)
+        {
+            this.typeRef = typeRef;
+            typeDef = typeRef.Resolve();
+            if (typeDef is null)
+            {
+
+            }
+            typeParamToArg = new Dictionary<string, TypeDefWithSelfRef>();
+            paramNames = Array.Empty<string>();
+
+            Il2CppTypeReflectionData tRef = typeRef;
+
+            if (typeRef.isArray)
+            {
+                tRef = typeRef.arrayType;
+            }
+
+            if (tRef.isGenericType)
+            {
+                paramNames = tRef.baseType.GenericContainer.GenericParameters.Select(p => p.Name).ToArray();
+                for (int i = 0; i < tRef.genericParams.Length; i++)
+                {
+                    typeParamToArg.Add(paramNames[i], new TypeDefWithSelfRef(tRef.genericParams[i]));
+                }
+            }
+        }
+
+        public void AssignTypeParams(TypeDefWithSelfRef parentTypeDef)
+        {
+            if (parentTypeDef.typeParamToArg.Count > 0 && typeRef.isGenericType)
+            {
+                for (int i = 0; i < typeRef.genericParams.Length; i++)
+                {
+                    Il2CppTypeReflectionData genTypeRef = typeRef.genericParams[i];
+                    if (!string.IsNullOrEmpty(genTypeRef.variableGenericParamName))
+                    {
+                        if (parentTypeDef.typeParamToArg.TryGetValue(genTypeRef.variableGenericParamName, out TypeDefWithSelfRef mappedType))
+                        {
+                            typeParamToArg[paramNames[i]] = mappedType;
+                        }
+                    }
+                }
+            }
+        }
+
+        public TypeDefWithSelfRef SolidifyType(TypeDefWithSelfRef typeDef)
+        {
+
+            if (typeDef.typeRef.ToString() == "T")
+            {
+
+            }
+
+            if (typeParamToArg.TryGetValue(typeDef.typeRef.ToString(), out TypeDefWithSelfRef retType))
+            {
+                return retType;
+            }
+
+
+            return typeDef;
+        }
+
+        public static implicit operator TypeDefWithSelfRef(Il2CppTypeReflectionData typeReference)
+        {
+            return new TypeDefWithSelfRef(typeReference);
+        }
+    }
+}

--- a/AssetsView/Winforms/GameObjectViewer.cs
+++ b/AssetsView/Winforms/GameObjectViewer.cs
@@ -187,10 +187,7 @@ namespace AssetsView.Winforms
                 children = atvf.Value.AsManagedReferencesRegistry.references.Select(r => r.data).ToList();
             else
                 children = atvf.Children;
-
-            if (children == null || children.Count == 0)
-                return;
-        
+                    
             string arrayName = string.Empty;
             if (atvf.Value != null && atvf.Value.ValueType == AssetValueType.ManagedReferencesRegistry) 
                 arrayName = atvf.TemplateField.Name;
@@ -251,6 +248,14 @@ namespace AssetsView.Winforms
                             PopulateDataGrid(atvfc, childProps, info, category, true);
                         }
                     }
+                }
+                else if (atvfc.IsDummy && atvf.Value != null && atvf.Value.ValueType == AssetValueType.ManagedReferencesRegistry)
+                {
+                    PGProperty prop = new PGProperty(key, "null");
+                    prop.category = category;
+                    SetSelectedStateIfSelected(info, prop);
+                    node.Add(prop);
+                    PopulateDataGrid(atvfc, prop, info, category);
                 }
                 else
                 {


### PR DESCRIPTION
1. Added MonoTemplateField and RefTypeManager cache. 
2. Rewrote `RefTypeManager` a bit.
3. Big update for `MonoCecilTempGenerator`.

I created some scriptable objects to test how things would serialize. They cover a big range of cases, hopefully all of them, but probably not. You can find them at https://github.com/KingEnderBrine/MonoBehaviourSerializationTests
Checked them on every minor Unity version from `2017.1` to `2022.2`. Also read all assets from the old version of `Risk of Rain 2` which used Unity 2018.4.16 with resources file.

I intend to also get `Cpp2IlTempGenerator` on par with `MonoCecilTempGenerator` and to simplify future changes I moved a lot of stuff that is independent of scripting backend out from `MonoCecilTempGenerator` to a separate class that can be used by both generators.