### PR TITLE
improve version matching.

### DIFF
--- a/AssetTools.NET/Standard/ClassDatabaseFile/ClassPackageClassInfo.cs
+++ b/AssetTools.NET/Standard/ClassDatabaseFile/ClassPackageClassInfo.cs
@@ -57,10 +57,19 @@ namespace AssetsTools.NET
                 return null;
             }
 
+            if (Classes[0].Key.ToUInt64() > version.ToUInt64())
+            {
+                return null;
+            }
+
             ClassPackageType lastType = Classes[0].Value;
             for (int i = 0; i < Classes.Count; i++)
             {
-                if (Classes[i].Key.ToUInt64() >= version.ToUInt64())
+                if (Classes[i].Key.ToUInt64() == version.ToUInt64())
+                {
+                    return Classes[i].Value;
+                }
+                if (Classes[i].Key.ToUInt64() > version.ToUInt64())
                 {
                     return lastType;
                 }


### PR DESCRIPTION
Previous implementation of `GetTypeForVersion` had 2 issues:

1- Returns entry 0 of `Classes` array regardless of target version (less, equal or more).
2- On equal, it would return the previous entry instead of matching version's class.

this `PR` should avoid those issues.