### PR TITLE
Asset file regex fix for custom versions containing a dash

### DIFF
--- a/AssetTools.NET/Standard/AssetsFileFormat/AssetsFile.cs
+++ b/AssetTools.NET/Standard/AssetsFileFormat/AssetsFile.cs
@@ -259,8 +259,8 @@ namespace AssetsTools.NET
                 }
             }
 
-            string emptyVersion = Regex.Replace(possibleVersion, "[a-zA-Z0-9\\.\\n]", "");
-            string fullVersion = Regex.Replace(possibleVersion, "[^a-zA-Z0-9\\.\\n]", "");
+            string emptyVersion = Regex.Replace(possibleVersion, "[a-zA-Z0-9\\.\\n\\-]", "");
+            string fullVersion = Regex.Replace(possibleVersion, "[^a-zA-Z0-9\\.\\n\\-]", "");
             return emptyVersion == "" && fullVersion.Length > 0;
         }
 


### PR DESCRIPTION
If the unity fs version is something like "2021.3.9f1-gamename", emptyVersion will resolve to "-", making it an invalid version. UABEA had similar issue here https://github.com/nesrak1/UABEA/issues/286