### PR TITLE
Fix ManagedReferencesRegistry's childCount writing

### DIFF
--- a/AssetTools.NET/Standard/AssetTypeClass/AssetTypeValueField.cs
+++ b/AssetTools.NET/Standard/AssetTypeClass/AssetTypeValueField.cs
@@ -277,7 +277,11 @@ namespace AssetsTools.NET
                         case AssetValueType.ManagedReferencesRegistry:
                             writer.Write(AsManagedReferencesRegistry.version);
                             int childCount = AsManagedReferencesRegistry.references.Count;
-                            
+
+                            if (AsManagedReferencesRegistry.version != 1)
+                            {
+                                writer.Write(childCount);
+                            }
                             for (int i = 0; i < childCount; i++)
                             {
                                 AssetTypeReferencedObject refdObject = AsManagedReferencesRegistry.references[i];


### PR DESCRIPTION
AssetTools.NET doesn't write childCount regardless ManagedReferencesRegistry version.
This pull request fixes it by writing childCount if version is not 1. 