### PR TITLE
MonoCecilTempGenerator - only check path if assembly not already loaded

### DIFF
--- a/AssetsTools.NET.MonoCecil/MonoCecilTempGenerator.cs
+++ b/AssetsTools.NET.MonoCecil/MonoCecilTempGenerator.cs
@@ -40,13 +40,24 @@ namespace AssetsTools.NET.Extra
                 assemblyName += ".dll";
             }
 
-            string assemblyPath = Path.Combine(managedPath, assemblyName);
-            if (!File.Exists(assemblyPath))
-            {
-                return null;
-            }
+            List<AssetTypeTemplateField> newFields;
 
-            List<AssetTypeTemplateField> newFields = Read(assemblyPath, nameSpace, className, unityVersion);
+            // if the assembly is already loaded, use it
+            if (loadedAssemblies.ContainsKey(assemblyName))
+            {
+                AssemblyDefinition asmDef = loadedAssemblies[assemblyName];
+                newFields = Read(asmDef, nameSpace, className, unityVersion);
+            }
+            else
+            // otherwise, try to read it from the managed path
+            {
+                string assemblyPath = Path.Combine(managedPath, assemblyName);
+                if (!File.Exists(assemblyPath))
+                {
+                    return null;
+                }
+                newFields = Read(assemblyPath, nameSpace, className, unityVersion);
+            }
 
             AssetTypeTemplateField newBaseField = baseField.Clone();
             newBaseField.Children.AddRange(newFields);


### PR DESCRIPTION
This PR slightly changes the behavior of ``MonoCecilTempGenerator.GetTemplateField``.
So far this function checked if the given assembly string corresponds to an existing ``.dll`` within the managed path.
This effectively prevents adding assemblies in other ways, e.g. from memory, or from different paths.

With this PR, the function first checks if the given assembly string corresponds to an already loaded assembly, and only if not, tries to load it from a file within the managed path.

