### PR TITLE
Return null instead of throwing Null Reference Exception on missing type

### DIFF
--- a/AssetTools.NET/Standard/AssetTypeClass/DummyFieldAccessException.cs
+++ b/AssetTools.NET/Standard/AssetTypeClass/DummyFieldAccessException.cs
@@ -8,11 +8,4 @@ namespace AssetsTools.NET
         {
         }
     }
-
-    public class NonexistentTypeException : Exception
-    {
-        public NonexistentTypeException(string assembly, string nameSpace, string typeName) : base(
-            $"Type `{(nameSpace != "" ? $"{nameSpace}." : "")}{typeName}` does not exist in assembly `{assembly}`"
-        ) {}
-    }
 }

--- a/AssetTools.NET/Standard/AssetTypeClass/DummyFieldAccessException.cs
+++ b/AssetTools.NET/Standard/AssetTypeClass/DummyFieldAccessException.cs
@@ -8,4 +8,11 @@ namespace AssetsTools.NET
         {
         }
     }
+
+    public class NonexistentTypeException : Exception
+    {
+        public NonexistentTypeException(string assembly, string nameSpace, string typeName) : base(
+            $"Type `{(nameSpace != "" ? $"{nameSpace}." : "")}{typeName}` does not exist in assembly `{assembly}`"
+        ) {}
+    }
 }

--- a/AssetsTools.NET.MonoCecil/MonoCecilTempGenerator.cs
+++ b/AssetsTools.NET.MonoCecil/MonoCecilTempGenerator.cs
@@ -125,6 +125,10 @@ namespace AssetsTools.NET.Extra
                 type = typeRef.Resolve();
             }
 
+            if (type == null) {
+                throw new NonexistentTypeException(module.Assembly.Name.Name, nameSpace, typeName);
+            }
+
             RecursiveTypeLoad(type, attf, availableDepth, true);
         }
 


### PR DESCRIPTION
Before it looked like a bug in the library, now you can more easily handle the null return value.