### PR TITLE
Fixed bug with opening same .bundle names

### DIFF
--- a/AssetTools.NET/Extra/AssetsManager/AssetsManager.Assets.cs
+++ b/AssetTools.NET/Extra/AssetsManager/AssetsManager.Assets.cs
@@ -6,7 +6,7 @@ namespace AssetsTools.NET.Extra
     {
         public static string GetFileLookupKey(string path)
         {
-            return Path.GetFileName(path).ToLower();
+            return Path.GetFullPath(path).ToLower();
         }
 
         private void LoadAssetsFileDependencies(AssetsFileInstance fileInst, string path, BundleFileInstance bunInst)

--- a/AssetTools.NET/Extra/AssetsManager/AssetsManager.Assets.cs
+++ b/AssetTools.NET/Extra/AssetsManager/AssetsManager.Assets.cs
@@ -6,7 +6,7 @@ namespace AssetsTools.NET.Extra
     {
         public static string GetFileLookupKey(string path)
         {
-            return Path.GetFullPath(path).ToLower();
+            return Path.GetFileName(path).ToLower();
         }
 
         private void LoadAssetsFileDependencies(AssetsFileInstance fileInst, string path, BundleFileInstance bunInst)

--- a/AssetTools.NET/Extra/AssetsManager/AssetsManager.Bundle.cs
+++ b/AssetTools.NET/Extra/AssetsManager/AssetsManager.Bundle.cs
@@ -4,6 +4,11 @@ namespace AssetsTools.NET.Extra
 {
     public partial class AssetsManager
     {
+        public static string GetBundleLookupKey(string path)
+        {
+            return Path.GetFullPath(path);
+        }
+
         /// <summary>
         /// Load a <see cref="BundleFileInstance"/> from a stream with a path.
         /// Use the <see cref="FileStream"/> version of this method to skip the path argument.
@@ -17,7 +22,7 @@ namespace AssetsTools.NET.Extra
         public BundleFileInstance LoadBundleFile(Stream stream, string path, bool unpackIfPacked = true)
         {
             BundleFileInstance bunInst;
-            string lookupKey = GetFileLookupKey(path);
+            string lookupKey = GetBundleLookupKey(path);
             if (BundleLookup.TryGetValue(lookupKey, out bunInst))
                 return bunInst;
 
@@ -68,7 +73,7 @@ namespace AssetsTools.NET.Extra
         /// <returns>True if the file was found and closed, and false if it wasn't found.</returns>
         public bool UnloadBundleFile(string path)
         {
-            string lookupKey = GetFileLookupKey(path);
+            string lookupKey = GetBundleLookupKey(path);
             if (BundleLookup.TryGetValue(lookupKey, out BundleFileInstance bunInst))
             {
                 bunInst.file.Close();
@@ -109,7 +114,7 @@ namespace AssetsTools.NET.Extra
 
             if (Bundles.Contains(bunInst))
             {
-                string lookupKey = GetFileLookupKey(bunInst.path);
+                string lookupKey = GetBundleLookupKey(bunInst.path);
                 lock (BundleLookup)
                 {
                     lock (Bundles)


### PR DESCRIPTION
This fixes the bug with opening .bundle files that have identical names. See the example in the video.
Game: Thronebreaker.
https://github.com/user-attachments/assets/44913c29-8c78-4ae7-83c9-c33c42037fb2

