### PR TITLE
Use array pool to plug memory leak

### DIFF
--- a/AssetTools.NET/AssetsTools.NET.csproj
+++ b/AssetTools.NET/AssetsTools.NET.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net35;net40</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net35;net40</TargetFrameworks>
     <OutputType>Library</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <Platforms>AnyCPU</Platforms>

--- a/AssetTools.NET/Extra/Net35Polyfill.cs
+++ b/AssetTools.NET/Extra/Net35Polyfill.cs
@@ -1,6 +1,10 @@
 ﻿using System;
 using System.IO;
 
+#if NETSTANDARD2_1_OR_GREATER
+using System.Buffers;
+#endif
+
 namespace AssetsTools.NET.Extra
 {
     public static class Net35Polyfill
@@ -8,18 +12,31 @@ namespace AssetsTools.NET.Extra
         //https://stackoverflow.com/a/13022108
         public static void CopyToCompat(this Stream input, Stream output, long bytes = -1, int bufferSize = 80 * 1024)
         {
+#if NETSTANDARD2_1_OR_GREATER
+            byte[] buffer = ArrayPool<byte>.Shared.Rent(bufferSize);
+#else
             byte[] buffer = new byte[bufferSize];
+#endif
             int read;
 
-            // set to largest value so we always go over buffer (hopefully)
-            if (bytes == -1)
-                bytes = long.MaxValue;
-
-            // bufferSize will always be an int so if bytes is larger, it's also under the size of an int
-            while (bytes > 0 && (read = input.Read(buffer, 0, (int)Math.Min(buffer.Length, bytes))) > 0)
+            try
             {
-                output.Write(buffer, 0, read);
-                bytes -= read;
+                // set to largest value so we always go over buffer (hopefully)
+                if (bytes == -1)
+                    bytes = long.MaxValue;
+
+                // bufferSize will always be an int so if bytes is larger, it's also under the size of an int
+                while (bytes > 0 && (read = input.Read(buffer, 0, (int)Math.Min(buffer.Length, bytes))) > 0)
+                {
+                    output.Write(buffer, 0, read);
+                    bytes -= read;
+                }
+            }
+            finally
+            {
+#if NETSTANDARD2_1_OR_GREATER
+            ArrayPool<byte>.Shared.Return(buffer);
+#endif
             }
         }
 

--- a/AssetTools.NET/Extra/Net35Polyfill.cs
+++ b/AssetTools.NET/Extra/Net35Polyfill.cs
@@ -14,29 +14,34 @@ namespace AssetsTools.NET.Extra
         {
 #if NETSTANDARD2_1_OR_GREATER
             byte[] buffer = ArrayPool<byte>.Shared.Rent(bufferSize);
-#else
-            byte[] buffer = new byte[bufferSize];
-#endif
-            int read;
 
             try
             {
-                // set to largest value so we always go over buffer (hopefully)
-                if (bytes == -1)
-                    bytes = long.MaxValue;
-
-                // bufferSize will always be an int so if bytes is larger, it's also under the size of an int
-                while (bytes > 0 && (read = input.Read(buffer, 0, (int)Math.Min(buffer.Length, bytes))) > 0)
-                {
-                    output.Write(buffer, 0, read);
-                    bytes -= read;
-                }
+                CopyToCompat(input, output, bytes, buffer);
             }
             finally
             {
-#if NETSTANDARD2_1_OR_GREATER
-            ArrayPool<byte>.Shared.Return(buffer);
+                ArrayPool<byte>.Shared.Return(buffer);
+            }
+#else
+            byte[] buffer = new byte[bufferSize];
+            CopyToCompat(input, output, bytes, buffer);
 #endif
+        }
+
+        private static void CopyToCompat(this Stream input, Stream output, long bytes, byte[] buffer)
+        {
+            int read;
+
+            // set to largest value so we always go over buffer (hopefully)
+            if (bytes == -1)
+                bytes = long.MaxValue;
+
+            // bufferSize will always be an int so if bytes is larger, it's also under the size of an int
+            while (bytes > 0 && (read = input.Read(buffer, 0, (int)Math.Min(buffer.Length, bytes))) > 0)
+            {
+                output.Write(buffer, 0, read);
+                bytes -= read;
             }
         }
 


### PR DESCRIPTION
This fixes an issue where the GC in unity mono is seemingly not competent enough to reclaim the memory from the buffer

(As discussed on discord a few weeks ago)

System.Buffers doesn't exist on NETSTANDARD2.0 which is why we need a separate target framework

ETA: I didn’t add it in the other frameworks because I’ve only used it in netstandard2.1, when I used at.net as part of a net10.0 app the garbage collector caught the garbage from this function so the arraypool wasn’t needed. It might be better to just include anyway