### PR TITLE
feat: add bundle helper function to calculate bundle's crc

### DIFF
--- a/AssetTools.NET/Extra/BundleHelper.cs
+++ b/AssetTools.NET/Extra/BundleHelper.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.IO;
 
 namespace AssetsTools.NET.Extra
@@ -121,6 +122,81 @@ namespace AssetsTools.NET.Extra
                 }
             }
             return null;
+        }
+
+        /// <summary>
+        /// Calculates the CRC32 (IEEE) of the bundle data stream.
+        /// This is the same CRC verified by Unity when loading an AssetBundle. It is independent of the 
+        /// compression method and depends only on the actual content; for compressed bundles, 
+        /// the data is unpacked before the CRC is calculated.
+        /// </summary>
+        /// <param name="bundle">Loaded bundle to calculate CRC for.</param>
+        /// <returns>CRC32 value.</returns>
+        public static uint CalculateBundleCrc32(AssetBundleFile bundle)
+        {
+            AssetBundleFile crcBundle = bundle;
+            bool closeCrcBundle = false;
+
+            if (bundle.DataIsCompressed)
+            {
+                crcBundle = UnpackBundle(bundle, false);
+                closeCrcBundle = true;
+            }
+
+            try
+            {
+                long totalDataLen = 0;
+                AssetBundleBlockInfo[] blocks = crcBundle.BlockAndDirInfo.BlockInfos;
+                for (int i = 0; i < blocks.Length; i++)
+                {
+                    totalDataLen += blocks[i].DecompressedSize;
+                }
+
+                AssetsFileReader dataReader = crcBundle.DataReader;
+                long oldPos = dataReader.Position;
+                try
+                {
+                    dataReader.Position = 0;
+                    uint crc = Crc32Helper.InitialValue;
+                    long consumed = 0;
+
+                    while (consumed < totalDataLen)
+                    {
+                        int toRead = (int)Math.Min(Crc32Helper.ChunkSize, totalDataLen - consumed);
+                        byte[] chunk = dataReader.ReadBytes(toRead);
+                        if (chunk.Length != toRead)
+                        {
+                            throw new EndOfStreamException(
+                                $"Unexpected end of bundle data while calculating CRC at 0x{consumed:X}."
+                            );
+                        }
+
+                        crc = Crc32Helper.Feed(crc, chunk);
+                        consumed += toRead;
+                    }
+
+                    return Crc32Helper.Finalize(crc);
+                }
+                finally
+                {
+                    dataReader.Position = oldPos;
+                }
+            }
+            finally
+            {
+                if (closeCrcBundle)
+                {
+                    try
+                    {
+                        crcBundle.Close();
+                    }
+                    catch
+                    {
+                        // some streams may have been closed during unpack operations
+                        // so we will ignore this
+                    }
+                }
+            }
         }
     }
 }

--- a/AssetTools.NET/Extra/Crc32Helper.cs
+++ b/AssetTools.NET/Extra/Crc32Helper.cs
@@ -1,0 +1,40 @@
+﻿namespace AssetsTools.NET.Extra
+{
+    public static class Crc32Helper
+    {
+        public const uint InitialValue = 0xFFFFFFFF;
+        public const int ChunkSize = 0x8000;
+
+        private static readonly uint[] Table = BuildTable();
+
+        public static uint Feed(uint crc, byte[] data)
+        {
+            for (int i = 0; i < data.Length; i++)
+            {
+                crc = Table[(crc ^ data[i]) & 0xFF] ^ (crc >> 8);
+            }
+            return crc;
+        }
+
+        public static uint Finalize(uint crc)
+        {
+            return ~crc;
+        }
+
+        private static uint[] BuildTable()
+        {
+            const uint poly = 0xEDB88320;
+            uint[] table = new uint[256];
+            for (uint i = 0; i < table.Length; i++)
+            {
+                uint c = i;
+                for (int j = 0; j < 8; j++)
+                {
+                    c = ((c & 1) != 0) ? ((c >> 1) ^ poly) : (c >> 1);
+                }
+                table[i] = c;
+            }
+            return table;
+        }
+    }
+}


### PR DESCRIPTION

I've implemented the same algorithm as Unity to calculate the CRC32 of an asset bundle in `AssetsTools.NET.Extra.BundleHelper.CalculateBundleCrc32`.


## Context
Discussions in the Discord AT/Tools Server:

ParaN3xus
> I'd like to add a feature to UABEANext to calculate Asset Bundle CRCs, which is the value returned by [BuildPipeline.GetCRCForAssetBundle()](https://docs.unity3d.com/6000.5/Documentation/ScriptReference/BuildPipeline.GetCRCForAssetBundle.html). 
> 
> Sometimes after modifying an asset bundle, we also need to update the CRC used for verification during loading so the application accepts the modded bundle. Unity does not natively expose an API to calculate this CRC (it is only output to the manifest during the build process); however, it can be retrieved by calling `AssetBundle.LoadFromFileAsync(path, someRandomCRCForVerification)` and checking the logs when the validation fails, e.g.
> ```
> CRC Mismatch. Provided [someRandomCRCForVerification], calculated [theRealCRC] from data. Will not load AssetBundle '[someRandom].assetbundle'
> ```
> 
> While this workaround works, it is quite inelegant. I have managed to figure out how Unity calculates this CRC (it is clearly not calculated directly on the raw asset bundle file) and have written a calculation script based on AssetsTools.NET that seems to work, now I am planning to integrate this feature into UABEANext. What do you think?

nes
> I have always bypassed crcs by setting them to 0. this is how the addressables catalog patcher works

ParaN3xus
> gotcha. but what if, like, they did a check to make sure the CRC check is not ignored

nes
> does your game do this? that'd be a first

ParaN3xus
> okay, they didn't

nes
> the way I'd do it is to add a bundle helper function to calculate the crc to assetstools just so there's code somewhere someone can run if someone needs to. I think it will be a rare situation to actually need to provide a non zero crc though.

ParaN3xus
> [reacted 👌]


## Notes
I decompiled and debugged `UnityPlayer.dll` (version 2022.3.62f3). By searching for the key constant `CRC Mismatch` mentioned in the logs, I located the following string:
```
.rdata:00007FFD54B310D0 aCrcMismatchPro db 'CRC Mismatch. Provided %x, calculated %x from data. Will not load'
```
And its two XREFs:
```
.rdata:00007FFD54B310D0                                         ; DATA XREF: AssetBundleLoadFromStreamAsyncOperation::FinalizeArchiveCreator(void):loc_7FFD537F38C5↑o
.rdata:00007FFD54B310D0                                         ; AssetBundleLoadFromAsyncOperation::InitializeAssetBundleStorage(FileSystemEntry &,VFS::FileSize,bool,unsigned __int64 *)+287↑o
```
I am focusing on the latter function. The critical section is
```c
if ( v18 )
{
  while ( 1 )
  {
    v24 = *(_QWORD *)(a1 + 176);
    v49 = 0;
    v25 = v18 - v23;
    v60 = v23;
    v48 = &v68;
    if ( v22 < v18 - v23 )
      v25 = v22;
    if ( !(unsigned __int8)ArchiveStorageReader::Read(v24, &v60, v25, v56, v48, v49) )
      break;
    if ( !v68 )
      break;
    v26 = CRCFeed(v17, v56, v68);
    v23 += v68;
    v17 = v26;
    if ( v23 >= v18 )
      break;
    v22 = v58;
  }
}
v27 = CRCDone(v17);
v28 = *(_DWORD *)(a1 + 200);

// ...

v31 = Format(
        &v65,
        "CRC Mismatch. Provided %x, calculated %x from data. Will not load AssetBundle '%s'",
        v28,
        v27,
        v30);
```
Here, `ArchiveStorageReader::Read` reveals what data is actually used for the CRC calculation. `Graphine::Performance::IPerformanceManager::GetMissingStreamingTiles` sets the initial CRC value, while `CRCFeed` and `CRCDone` represent the actual calculation process. Let's examine them one by one:
- `ArchiveStorageReader::Read`: This function treats all blocks within the AssetBundle as a continuous virtual byte stream and performs reads at specified offsets and sizes. Key parts:
  ```c
  while ( 1 )
  {
    // virtual offset
    v22 = v50;

    // block index >= total_blocks
    if ( v21 >= v13 )
      goto LABEL_22;

    // starting offsets in the virtual byte stream of all blocks
    v23 = *(_QWORD *)(a1 + 280);

    // next block index = block_index + 1
    v24 = v21 + 1;

    // starting offset of current block in the virtual byte stream
    v25 = (_QWORD *)(v23 + 8LL * v21);
    // size of current block
    v26 = *(_QWORD *)(v23 + 8 * v24) - *v25;

    if ( *v25 > v18 + *v50 )
      goto LABEL_22;

    // remaining size = requested size - read
    v27 = a3 - v18;

    // if it's the first iter
    if ( v21 == v14 )
    {
      // offset in this block
      v28 = *(_DWORD *)v50 - *(_DWORD *)v25;
      // max size to read in this block
      v29 = v26 - v28;

      v49 = 0;
      
      // if this block if enough
      if ( v27 < (unsigned int)v26 - v28 )
        // read all remaining size
        v29 = a3 - v18;
      // else read full block. if so, v28 should be 0
      v30 = v29;
      if ( v28 )
        goto LABEL_18;
    }
    else // not the first iter
    {
      v28 = 0;
      // size of current block
      v30 = (unsigned int)v26;
      v49 = 0;
      // remaining size < block size
      if ( v27 < (unsigned int)v26 )
        // only read bytes of remaining size
        v30 = v27;
    }
    if ( v30 == v26 && (a6 & 1) == 0 )
    {
      // read complete block
      if ( !ArchiveStorageReader::ReadCompleteBlock(
              (ArchiveStorageReader *)a1,
              v21,
              (char *)v51 + v18, // buf
              &v49,
              (struct ArchiveStorageReader::BatchingFileReader *)&v37) )
      {
        core::vector<UnityEngine::Animation::GenericAnimationBindingCache::CustomBinding,0>::~vector<UnityEngine::Animation::GenericAnimationBindingCache::CustomBinding,0>(&v45);
        return 0;
      }
      goto LABEL_19;
    }
  LABEL_18:
    // read part of the block
    if ( !ArchiveStorageReader::ReadBlock(
            (ArchiveStorageReader *)a1,
            v21,
            v28,
            v30,
            (char *)v51 + v18, // buf
            &v49,
            (struct ArchiveStorageReader::BatchingFileReader *)&v37) )
    {
      v31 = v18;
      v32 = v18 != 0;
      goto LABEL_27;
    }
  LABEL_19:
    // read += iter_read
    v18 += v49;

    // read done
    if ( v49 >= v30 )
    {
      // move to the next block
      v21 = v24;

      // not enough
      if ( v18 < a3 )
        continue;
    }
    v22 = v50;
  LABEL_22:
    v6 = (char *)v51;

    // exit
    goto LABEL_23;
  }
  LABEL_23: 
  ...
  ```
- `Graphine::Performance::IPerformanceManager::GetMissingStreamingTiles`: 
  ```c
  __int64 __fastcall Graphine::Performance::IPerformanceManager::GetMissingStreamingTiles(
          Graphine::Performance::IPerformanceManager *this)
  {
    return 0xFFFFFFFFLL;
  }
  ```
- `CRCFeed`
  ```c
  __int64 __fastcall CRCFeed(unsigned int a1, const unsigned __int8 *a2, __int64 a3)
  {
    __int64 v3; // rax

    for ( ; a3; --a3 )
    {
      v3 = *a2++;
      a1 = (a1 >> 8) ^ dword_7FFD54A4D5F0[v3 ^ (unsigned __int8)a1];
    }
    return a1;
  }
  ```
  where `dword_7FFD54A4D5F0` is 
  ```
  .rdata:00007FFD54A4D5F0 dword_7FFD54A4D5F0 dd 0, 77073096h, 0EE0E612Ch, 990951BAh, 76DC419h, 706AF48Fh
  .rdata:00007FFD54A4D5F0                                         ; DATA XREF: CRCFeed(uint,uchar const *,unsigned __int64)+5↑o
  .rdata:00007FFD54A4D608                 dd 0E963A535h, 9E6495A3h, 0EDB8832h, 79DCB8A4h, 0E0D5E91Eh
  ...
  ```
  Clearly, this is standard IEEE CRC32.
- `CRCDone`
  ```c
  __int64 __fastcall CRCDone(int a1)
  {
    return (unsigned int)~a1;
  }
  ```