### PR TITLE
feat: parallel compression for LZ4

### DIFF
--- a/AssetTools.NET/Standard/AssetsBundleFileFormat/AssetBundleFile.cs
+++ b/AssetTools.NET/Standard/AssetsBundleFileFormat/AssetBundleFile.cs
@@ -30,12 +30,23 @@ namespace AssetsTools.NET
         /// </summary>
         public bool DataIsCompressed { get; set; }
 
+        private static int _lz4ParallelPackBatchSize = 32;
         /// <summary>
-        /// Number of 0x20000 blocks processed per parallel batch in LZ4/LZ4Fast Pack.
+        /// Number of 0x20000 blocks processed per parallel batch in LZ4/LZ4Fast Pack/Unpack.
         /// Used on non-NET35 targets only. Values less than 1 are treated as 1.
         /// </summary>
-        public static int Lz4ParallelPackBatchSize { get; set; } = 32;
-
+        public static int Lz4ParallelPackBatchSize
+        {
+            get => _lz4ParallelPackBatchSize;
+            set
+            {
+                if (value <= 0)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(value), "Lz4ParallelPackBatchSize must be greater than 0.");
+                }
+                _lz4ParallelPackBatchSize = value;
+            }
+        }
         public AssetsFileReader Reader;
 
         /// <summary>
@@ -504,16 +515,13 @@ namespace AssetsTools.NET
                         writeStream = GetTempFileStream();
 
 #if !NET35
-                    int batchSize = Lz4ParallelPackBatchSize;
-                    if (batchSize < 1)
-                        batchSize = 1;
                     int totalBlockCount = (int)((bundleDataReader.BaseStream.Length + blockSize - 1) / blockSize);
                     int completedBlockCount = 0;
 
                     while (true)
                     {
-                        List<byte[]> uncompressedBlocks = new List<byte[]>(batchSize);
-                        for (int i = 0; i < batchSize; i++)
+                        List<byte[]> uncompressedBlocks = new List<byte[]>(_lz4ParallelPackBatchSize);
+                        for (int i = 0; i < _lz4ParallelPackBatchSize; i++)
                         {
                             byte[] block = bundleDataReader.ReadBytes(blockSize);
                             if (block.Length == 0)

--- a/AssetTools.NET/Standard/AssetsBundleFileFormat/AssetBundleFile.cs
+++ b/AssetTools.NET/Standard/AssetsBundleFileFormat/AssetBundleFile.cs
@@ -5,6 +5,9 @@ using SevenZip.Compression.LZMA;
 using System;
 using System.Collections.Generic;
 using System.IO;
+#if !NET35
+using System.Threading.Tasks;
+#endif
 
 namespace AssetsTools.NET
 {
@@ -26,6 +29,12 @@ namespace AssetsTools.NET
         /// Is data reader reading compressed data? Only LZMA bundles set this to true.
         /// </summary>
         public bool DataIsCompressed { get; set; }
+
+        /// <summary>
+        /// Number of 0x20000 blocks processed per parallel batch in LZ4/LZ4Fast Pack.
+        /// Used on non-NET35 targets only. Values less than 1 are treated as 1.
+        /// </summary>
+        public static int Lz4ParallelPackBatchSize { get; set; } = 32;
 
         public AssetsFileReader Reader;
 
@@ -485,6 +494,7 @@ namespace AssetsTools.NET
                 case AssetBundleCompressionType.LZ4Fast:
                 {
                     // compress into 0x20000 blocks
+                    const int blockSize = 0x20000;
                     BinaryReader bundleDataReader = new BinaryReader(bundleDataStream);
 
                     Stream writeStream;
@@ -493,7 +503,78 @@ namespace AssetsTools.NET
                     else
                         writeStream = GetTempFileStream();
 
-                    byte[] uncompressedBlock = bundleDataReader.ReadBytes(0x20000);
+#if !NET35
+                    int batchSize = Lz4ParallelPackBatchSize;
+                    if (batchSize < 1)
+                        batchSize = 1;
+                    int totalBlockCount = (int)((bundleDataReader.BaseStream.Length + blockSize - 1) / blockSize);
+                    int completedBlockCount = 0;
+
+                    while (true)
+                    {
+                        List<byte[]> uncompressedBlocks = new List<byte[]>(batchSize);
+                        for (int i = 0; i < batchSize; i++)
+                        {
+                            byte[] block = bundleDataReader.ReadBytes(blockSize);
+                            if (block.Length == 0)
+                                break;
+                            uncompressedBlocks.Add(block);
+                        }
+
+                        if (uncompressedBlocks.Count == 0)
+                            break;
+
+                        // each outputBlock is a byte[]
+                        byte[][] outputBlocks = new byte[uncompressedBlocks.Count][];
+                        AssetBundleBlockInfo[] outputBlockInfos = new AssetBundleBlockInfo[uncompressedBlocks.Count];
+
+                        Parallel.For(0, uncompressedBlocks.Count, i =>
+                        {
+                            byte[] uncompressedBlock = uncompressedBlocks[i];
+                            byte[] compressedBlock = compType == AssetBundleCompressionType.LZ4Fast
+                                ? LZ4Codec.Encode32(uncompressedBlock, 0, uncompressedBlock.Length)
+                                : LZ4Codec.Encode32HC(uncompressedBlock, 0, uncompressedBlock.Length);
+
+                            if (compressedBlock.Length > uncompressedBlock.Length)
+                            {
+                                outputBlocks[i] = uncompressedBlock;
+                                outputBlockInfos[i] = new AssetBundleBlockInfo()
+                                {
+                                    CompressedSize = (uint)uncompressedBlock.Length,
+                                    DecompressedSize = (uint)uncompressedBlock.Length,
+                                    Flags = 0x00
+                                };
+                            }
+                            else
+                            {
+                                outputBlocks[i] = compressedBlock;
+                                outputBlockInfos[i] = new AssetBundleBlockInfo()
+                                {
+                                    CompressedSize = (uint)compressedBlock.Length,
+                                    DecompressedSize = (uint)uncompressedBlock.Length,
+                                    Flags = 0x03
+                                };
+                            }
+                        });
+
+                        for (int i = 0; i < outputBlocks.Length; i++)
+                        {
+                            byte[] outputBlock = outputBlocks[i];
+                            AssetBundleBlockInfo blockInfo = outputBlockInfos[i];
+
+                            writeStream.Write(outputBlock, 0, outputBlock.Length);
+                            totalCompressedSize += blockInfo.CompressedSize;
+                            newBlocks.Add(blockInfo);
+                        }
+
+                        completedBlockCount += outputBlocks.Length;
+                        if (progress != null && totalBlockCount > 0)
+                        {
+                            progress.SetProgress((float)completedBlockCount / totalBlockCount);
+                        }
+                    }
+#else
+                    byte[] uncompressedBlock = bundleDataReader.ReadBytes(blockSize);
                     while (uncompressedBlock.Length != 0)
                     {
                         byte[] compressedBlock = compType == AssetBundleCompressionType.LZ4Fast
@@ -536,8 +617,9 @@ namespace AssetsTools.NET
                             newBlocks.Add(blockInfo);
                         }
 
-                        uncompressedBlock = bundleDataReader.ReadBytes(0x20000);
+                        uncompressedBlock = bundleDataReader.ReadBytes(blockSize);
                     }
+#endif
 
                     if (!blockDirAtEnd)
                         newStreams.Add(writeStream);


### PR DESCRIPTION
This PR introduces a parallel compression path for LZ4/LZ4Fast in bundle packing. To preserve compatibility with `net35` targets, this parallel path is only enabled on non-`net35` builds, while `net35` continues using the original sequential implementation.

The mechanism is straightforward: it takes a batch of consecutive blocks and compresses them concurrently with `Parallel.For`. The batch size is configurable through `Lz4ParallelPackBatchSize`, with a default value of `32`. This default was selected based on benchmarking on my local laptop (Intel(R) Core(TM) i7-13650HX, 32G DDR5 mem, Linux 6.6.87.2-microsoft-standard-WSL2). In the benchmarking, I used a byte-counting stream to eliminate the impact of disk I/O.

Benchmarking logs are
```
Data length: 1,142,981,560 bytes
CPU: 20 logical cores

=== LZ4Fast ===
Warmup: 1, Measured: 3
batch=   1 | avg=  3069.20 ms | min=  2996.73 ms | out= 699,313,746 bytes
batch=   2 | avg=  1949.53 ms | min=  1925.55 ms | out= 699,313,746 bytes
batch=   4 | avg=  1374.78 ms | min=  1360.78 ms | out= 699,313,746 bytes
batch=   8 | avg=  1235.22 ms | min=  1231.19 ms | out= 699,313,746 bytes
batch=  16 | avg=  1274.38 ms | min=  1255.26 ms | out= 699,313,746 bytes
batch=  32 | avg=  1000.09 ms | min=   981.35 ms | out= 699,313,746 bytes
batch=  64 | avg=  1015.87 ms | min=   971.02 ms | out= 699,313,746 bytes
batch=  96 | avg=   979.19 ms | min=   963.95 ms | out= 699,313,746 bytes
batch= 128 | avg=  1018.69 ms | min=  1016.70 ms | out= 699,313,746 bytes
batch= 192 | avg=  1127.88 ms | min=  1005.42 ms | out= 699,313,746 bytes
batch= 256 | avg=   962.32 ms | min=   860.11 ms | out= 699,313,746 bytes
batch= 384 | avg=   941.29 ms | min=   894.33 ms | out= 699,313,746 bytes
batch= 512 | avg=   951.07 ms | min=   918.96 ms | out= 699,313,746 bytes
Best for LZ4Fast: batch=384, avg=941.29 ms, min=894.33 ms

=== LZ4 ===
Warmup: 1, Measured: 3
batch=   1 | avg= 23305.73 ms | min= 23240.59 ms | out= 644,689,762 bytes
batch=   2 | avg= 13358.26 ms | min= 13265.65 ms | out= 644,689,762 bytes
batch=   4 | avg=  8143.68 ms | min=  8137.16 ms | out= 644,689,762 bytes
batch=   8 | avg=  6423.89 ms | min=  6346.14 ms | out= 644,689,762 bytes
batch=  16 | avg=  5454.16 ms | min=  5396.60 ms | out= 644,689,762 bytes
batch=  32 | avg=  5064.66 ms | min=  5032.62 ms | out= 644,689,762 bytes
batch=  64 | avg=  5174.30 ms | min=  5108.39 ms | out= 644,689,762 bytes
batch=  96 | avg=  4748.79 ms | min=  4643.74 ms | out= 644,689,762 bytes
batch= 128 | avg=  5115.96 ms | min=  4897.92 ms | out= 644,689,762 bytes
batch= 192 | avg=  5628.60 ms | min=  5033.43 ms | out= 644,689,762 bytes
batch= 256 | avg=  5217.21 ms | min=  4852.48 ms | out= 644,689,762 bytes
batch= 384 | avg=  4272.61 ms | min=  4254.14 ms | out= 644,689,762 bytes
batch= 512 | avg=  4529.81 ms | min=  4433.02 ms | out= 644,689,762 bytes
Best for LZ4: batch=384, avg=4272.61 ms, min=4254.14 ms
```

I know this implementation still does not fully saturate all available performance potential, but in my observation it already keeps CPU utilization stably above 80%, which is sufficient for most cases.