### PR TITLE
bug: AssetRipper cannot read asset bundles written by AssetsTools.NET with `BlockInfoNeedPaddingAtStart` flag

### DIFF
--- a/AssetTools.NET/Standard/AssetsBundleFileFormat/AssetBundleFile.cs
+++ b/AssetTools.NET/Standard/AssetsBundleFileFormat/AssetBundleFile.cs
@@ -173,12 +173,12 @@ namespace AssetsTools.NET
             newBundleInf.DirectoryInfos = dirInfos;
             newBundleInf.Write(writer);
 
+            long assetDataPos = writer.Position;
+
             if ((Header.FileStreamHeader.Flags & AssetBundleFSHeaderFlags.BlockInfoNeedPaddingAtStart) != 0)
             {
                 writer.Align16();
             }
-
-            long assetDataPos = writer.Position;
 
             // write the updated directory infos
             for (int i = 0; i < dirInfos.Count; i++)


### PR DESCRIPTION
I noticed that AssetRipper will fail to read AssetsTools.NET asset bundles created with the `BlockInfoNeedPaddingAtStart` flag because AssetRipper expects the blocks info length to not be aligned to the next multiple of 16 bytes. 

You can see that in these lines:
 - https://github.com/AssetRipper/AssetRipper/blob/7b026f34aa80885bc5b2258b17d835723a5b2d83/Source/AssetRipper.IO.Files/BundleFiles/FileStream/FileStreamBundleFile.cs#L62
 - https://github.com/AssetRipper/AssetRipper/blob/7b026f34aa80885bc5b2258b17d835723a5b2d83/Source/AssetRipper.IO.Files/BundleFiles/FileStream/FileStreamBundleFile.cs#L116

AssetRipper will not attempt to increase the blocks info length to the next multiple of 16 before validating that the number of bytes read is correct. This contrasts with AssetsTools.NET which does align to the next multiple of 16 before calculating length. I'm not sure which tool's behavior is correct, but I figured I'd just open a PR for whichever fix was easier.

Here's the minimum reproducible code:
```cs
AssetBundleDirectoryInfo dirInfo = AssetBundleDirectoryInfo.Create("test", true);
dirInfo.SetNewData(Encoding.ASCII.GetBytes("this is test data"));
AssetBundleFile bundleFile = new()
{
    Header = new AssetBundleHeader
    {
        Signature = "UnityFS",
        Version = 7,
        GenerationVersion = "5.x.x",
        EngineVersion = "2020.3.36f1",
        FileStreamHeader = new AssetBundleFSHeader()
        {
            Flags = AssetBundleFSHeaderFlags.BlockInfoNeedPaddingAtStart | AssetBundleFSHeaderFlags.HasDirectoryInfo
        }
    },
    BlockAndDirInfo = new AssetBundleBlockAndDirInfo
    {
        DirectoryInfos = 
        [
            dirInfo,
        ],
    }
};

using (FileStream stream = File.OpenWrite("test.unity3d"))
using (AssetsFileWriter writer = new(stream))
{
    bundleFile.Write(writer);
}
```
The bundle this generates will fail to load in AssetRipper, but if you change the uncompressed blocks info length to 59 (0x3B) using a hex editor, it will load in AssetRipper just fine.