### PR TITLE
Update Cpp2IL Lib

### DIFF
--- a/AssetsTools.NET.Cpp2IL/AssetsTools.NET.Cpp2IL.csproj
+++ b/AssetsTools.NET.Cpp2IL/AssetsTools.NET.Cpp2IL.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Samboy063.LibCpp2IL" Version="2022.1.0-pre-release.19" />
+    <PackageReference Include="Samboy063.LibCpp2IL" Version="2022.1.0-pre-release.21" />
   </ItemGroup>
 
   <ItemGroup>

--- a/AssetsTools.NET.Cpp2IL/Cpp2IlTempGenerator.cs
+++ b/AssetsTools.NET.Cpp2IL/Cpp2IlTempGenerator.cs
@@ -108,7 +108,7 @@ namespace AssetsTools.NET.Cpp2IL
 
             if (type == null)
             {
-                throw new Exception($"Type \"{classFullName}\" was not found.");
+                throw new Exception($"Type \"{classFullName}\" was not found in the IL2CPP metadata.");
             }
 
             Il2CppTypeReflectionData typeRef = new Il2CppTypeReflectionData

--- a/AssetsTools.NET.Cpp2IL/Cpp2IlTempGenerator.cs
+++ b/AssetsTools.NET.Cpp2IL/Cpp2IlTempGenerator.cs
@@ -153,8 +153,8 @@ namespace AssetsTools.NET.Cpp2IL
             Il2CppCustomAttributeDataRange attributeDataRange = metadata.AttributeDataRanges[caIndex];
             Il2CppCustomAttributeDataRange next = metadata.AttributeDataRanges[caIndex + 1];
 
-            long blobStart = metadata.metadataHeader.attributeDataOffset + attributeDataRange.startOffset;
-            long blobEnd = metadata.metadataHeader.attributeDataOffset + next.startOffset;
+            long blobStart = metadata.metadataHeader.attributeData.Offset + attributeDataRange.startOffset;
+            long blobEnd = metadata.metadataHeader.attributeData.Offset + next.startOffset;
 
             return metadata.ReadByteArrayAtRawAddress(blobStart, (int)(blobEnd - blobStart));
         }
@@ -178,7 +178,7 @@ namespace AssetsTools.NET.Cpp2IL
                 foreach (uint attrIdx in parsedCustomAttrData.attributeIndices)
                 {
                     var attrCtorMethod = metadata.methodDefs[attrIdx];
-                    var attrType = metadata.typeDefs[attrCtorMethod.declaringTypeIdx];
+                    var attrType = metadata.typeDefs[attrCtorMethod.declaringTypeIdx.Value];
                     attributeNames.Add(attrType.FullName);
                 }
 
@@ -196,7 +196,7 @@ namespace AssetsTools.NET.Cpp2IL
                 for (int attributeIdx = 0; attributeIdx < attributeTypeRange.count; attributeIdx++)
                 {
                     var attributeTypeIndex = metadata.attributeTypes[attributeTypeRange.start + attributeIdx];
-                    var attributeTypeDef = metadata.typeDefs.FirstOrDefault(td => td.ByvalTypeIndex == attributeTypeIndex);
+                    var attributeTypeDef = metadata.typeDefs.FirstOrDefault(td => td.ByvalTypeIndex.IsNonNull && td.ByvalTypeIndex.Value == attributeTypeIndex);
                     if (attributeTypeDef != null)
                     {
                         attributeNames.Add(attributeTypeDef.FullName);

--- a/AssetsTools.NET.Cpp2IL/Cpp2IlTempGenerator.cs
+++ b/AssetsTools.NET.Cpp2IL/Cpp2IlTempGenerator.cs
@@ -95,19 +95,22 @@ namespace AssetsTools.NET.Cpp2IL
 
             Il2CppMetadata meta = LibCpp2IlMain.TheMetadata;
 
-            Il2CppAssemblyDefinition asm = meta.AssemblyDefinitions.ToList().First(a => a.AssemblyName.Name == assemblyName);
-            if (asm == null)
-            {
-                throw new Exception($"Assembly \"{assemblyName}\" was not found in the IL2CPP metadata.");
-            }
+            string classFullName = string.IsNullOrEmpty(nameSpace) ? className : $"{nameSpace}.{className}";
 
-            string fullName = $"{nameSpace}{(string.IsNullOrEmpty(nameSpace) ? "" : ".")}{className}";
+            // Find class in all assemblies if namespace and name matсh
+            // so MonoBehaviour might has common assemble name UnityEngine.dll
+            // but class actually be located in submodule UnityEngine.TextCoreTextEngineModule.dll
 
-            Il2CppTypeDefinition type = asm.Image.Types.FirstOrDefault(t => t.FullName == fullName);
+            Il2CppTypeDefinition type = meta.AssemblyDefinitions
+                .Where(asm => asm.AssemblyName.Name.StartsWith(assemblyName, StringComparison.OrdinalIgnoreCase))
+                .SelectMany(asm => asm.Image.Types)
+                .FirstOrDefault(t => t.FullName == classFullName);
+
             if (type == null)
             {
-                throw new Exception($"Type \"{nameSpace}::{className}\" was not found in the IL2CPP metadata.");
+                throw new Exception($"Type \"{classFullName}\" was not found.");
             }
+
             Il2CppTypeReflectionData typeRef = new Il2CppTypeReflectionData
             {
                 baseType = type,


### PR DESCRIPTION
 This PRs has:
- update [Cpp2IL](https://github.com/SamboyCoding/Cpp2IL) to 2022.1.0-pre-release.21  for support Unity 6 (fix #160)
- support find type lookup in modularized assemblies