### PR TITLE
Initialize TypeBlob when creating new AssetFileInfo

### DIFF
--- a/AssetTools.NET/Standard/AssetsFileFormat/AssetFileInfo.cs
+++ b/AssetTools.NET/Standard/AssetsFileFormat/AssetFileInfo.cs
@@ -318,8 +318,11 @@ namespace AssetsTools.NET
                             ScriptTypeIndex = scriptIndex,
                             ScriptIdHash = Hash128.NewBlankHash(),
                             TypeHash = Hash128.NewBlankHash(),
-                            Nodes = new List<TypeTreeNode>(),
-                            StringBufferBytes = new byte[0],
+                            TypeBlob = new TypeTreeBlob()
+                            {
+                                Nodes = new List<TypeTreeNode>(),
+                                StringBufferBytes = new byte[0]
+                            },
                             TypeDependencies = new int[0],
                             IsRefType = false,
                             TypeReference = null,


### PR DESCRIPTION
Fixes regression from commit c57e61d where a `TypeBlob` stores `Nodes` and `StringBufferBytes`, rather than being stored directly within the `TypeTreeType`, but the Create method does not initialize one.